### PR TITLE
feat: add foreign key contraints

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -10,7 +10,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/hanjunlee/gitploy/ent"
-	"github.com/hanjunlee/gitploy/ent/migrate"
 	"github.com/hanjunlee/gitploy/internal/interactor"
 	"github.com/hanjunlee/gitploy/internal/pkg/github"
 	"github.com/hanjunlee/gitploy/internal/pkg/store"
@@ -122,7 +121,6 @@ func newStore(c *Config) interactor.Store {
 
 	err = client.Schema.Create(
 		context.Background(),
-		migrate.WithForeignKeys(false),
 	)
 	if err != nil {
 		log.Fatalf("failed creating schema resources: %v", err)

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -27,7 +27,7 @@ var (
 				Symbol:     "approvals_deployments_approvals",
 				Columns:    []*schema.Column{ApprovalsColumns[4]},
 				RefColumns: []*schema.Column{DeploymentsColumns[0]},
-				OnDelete:   schema.SetNull,
+				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "approvals_users_approvals",
@@ -64,7 +64,7 @@ var (
 				Symbol:     "chat_callbacks_repos_chat_callback",
 				Columns:    []*schema.Column{ChatCallbacksColumns[7]},
 				RefColumns: []*schema.Column{ReposColumns[0]},
-				OnDelete:   schema.SetNull,
+				OnDelete:   schema.Cascade,
 			},
 		},
 	}
@@ -89,14 +89,7 @@ var (
 				Symbol:     "chat_users_users_chat_user",
 				Columns:    []*schema.Column{ChatUsersColumns[7]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
-				OnDelete:   schema.SetNull,
-			},
-		},
-		Indexes: []*schema.Index{
-			{
-				Name:    "chatuser_user_id",
-				Unique:  false,
-				Columns: []*schema.Column{ChatUsersColumns[7]},
+				OnDelete:   schema.Cascade,
 			},
 		},
 	}
@@ -128,7 +121,7 @@ var (
 				Symbol:     "deployments_repos_deployments",
 				Columns:    []*schema.Column{DeploymentsColumns[13]},
 				RefColumns: []*schema.Column{ReposColumns[0]},
-				OnDelete:   schema.SetNull,
+				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "deployments_users_deployments",
@@ -138,16 +131,6 @@ var (
 			},
 		},
 		Indexes: []*schema.Index{
-			{
-				Name:    "deployment_user_id",
-				Unique:  false,
-				Columns: []*schema.Column{DeploymentsColumns[14]},
-			},
-			{
-				Name:    "deployment_repo_id",
-				Unique:  false,
-				Columns: []*schema.Column{DeploymentsColumns[13]},
-			},
 			{
 				Name:    "deployment_repo_id_env_created_at",
 				Unique:  false,
@@ -190,14 +173,7 @@ var (
 				Symbol:     "deployment_status_deployments_deployment_statuses",
 				Columns:    []*schema.Column{DeploymentStatusColumns[6]},
 				RefColumns: []*schema.Column{DeploymentsColumns[0]},
-				OnDelete:   schema.SetNull,
-			},
-		},
-		Indexes: []*schema.Index{
-			{
-				Name:    "deploymentstatus_deployment_id",
-				Unique:  false,
-				Columns: []*schema.Column{DeploymentStatusColumns[6]},
+				OnDelete:   schema.Cascade,
 			},
 		},
 	}
@@ -231,15 +207,10 @@ var (
 				Symbol:     "notifications_users_notification",
 				Columns:    []*schema.Column{NotificationsColumns[16]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
-				OnDelete:   schema.SetNull,
+				OnDelete:   schema.Cascade,
 			},
 		},
 		Indexes: []*schema.Index{
-			{
-				Name:    "notification_user_id",
-				Unique:  false,
-				Columns: []*schema.Column{NotificationsColumns[16]},
-			},
 			{
 				Name:    "notification_user_id_created_at",
 				Unique:  false,
@@ -267,26 +238,16 @@ var (
 				Symbol:     "perms_repos_perms",
 				Columns:    []*schema.Column{PermsColumns[5]},
 				RefColumns: []*schema.Column{ReposColumns[0]},
-				OnDelete:   schema.SetNull,
+				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "perms_users_perms",
 				Columns:    []*schema.Column{PermsColumns[6]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
-				OnDelete:   schema.SetNull,
+				OnDelete:   schema.Cascade,
 			},
 		},
 		Indexes: []*schema.Index{
-			{
-				Name:    "perm_user_id",
-				Unique:  false,
-				Columns: []*schema.Column{PermsColumns[6]},
-			},
-			{
-				Name:    "perm_repo_id",
-				Unique:  false,
-				Columns: []*schema.Column{PermsColumns[5]},
-			},
 			{
 				Name:    "perm_repo_id_user_id",
 				Unique:  false,

--- a/ent/schema/chatuser.go
+++ b/ent/schema/chatuser.go
@@ -6,7 +6,6 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
-	"entgo.io/ent/schema/index"
 )
 
 // ChatUser holds the schema definition for the ChatUser entity.
@@ -43,11 +42,5 @@ func (ChatUser) Edges() []ent.Edge {
 			Field("user_id").
 			Unique().
 			Required(),
-	}
-}
-
-func (ChatUser) Indexes() []ent.Index {
-	return []ent.Index{
-		index.Fields("user_id"),
 	}
 }

--- a/ent/schema/deployment.go
+++ b/ent/schema/deployment.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"entgo.io/ent"
+	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
@@ -71,15 +72,19 @@ func (Deployment) Edges() []ent.Edge {
 			Field("repo_id").
 			Unique().
 			Required(),
-		edge.To("approvals", Approval.Type),
-		edge.To("deployment_statuses", DeploymentStatus.Type),
+		edge.To("approvals", Approval.Type).
+			Annotations(entsql.Annotation{
+				OnDelete: entsql.Cascade,
+			}),
+		edge.To("deployment_statuses", DeploymentStatus.Type).
+			Annotations(entsql.Annotation{
+				OnDelete: entsql.Cascade,
+			}),
 	}
 }
 
 func (Deployment) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("user_id"),
-		index.Fields("repo_id"),
 		// Basically deployments are ordered by created_at field.
 		index.Fields("repo_id", "env", "created_at"),
 		index.Fields("repo_id", "created_at"),

--- a/ent/schema/deploymentstatus.go
+++ b/ent/schema/deploymentstatus.go
@@ -6,7 +6,6 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
-	"entgo.io/ent/schema/index"
 )
 
 // DeploymentStatus holds the schema definition for the DeploymentStatus entity.
@@ -41,11 +40,5 @@ func (DeploymentStatus) Edges() []ent.Edge {
 			Field("deployment_id").
 			Unique().
 			Required(),
-	}
-}
-
-func (DeploymentStatus) Indexes() []ent.Index {
-	return []ent.Index{
-		index.Fields("deployment_id"),
 	}
 }

--- a/ent/schema/notification.go
+++ b/ent/schema/notification.go
@@ -65,7 +65,6 @@ func (Notification) Edges() []ent.Edge {
 
 func (Notification) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("user_id"),
 		index.Fields("user_id", "created_at"),
 	}
 }

--- a/ent/schema/perm.go
+++ b/ent/schema/perm.go
@@ -55,8 +55,6 @@ func (Perm) Edges() []ent.Edge {
 
 func (Perm) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("user_id"),
-		index.Fields("repo_id"),
 		index.Fields("repo_id", "user_id"),
 	}
 }

--- a/ent/schema/repo.go
+++ b/ent/schema/repo.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"entgo.io/ent"
+	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 )
@@ -43,8 +44,17 @@ func (Repo) Fields() []ent.Field {
 // Edges of the Repo.
 func (Repo) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.To("perms", Perm.Type),
-		edge.To("deployments", Deployment.Type),
-		edge.To("chat_callback", ChatCallback.Type),
+		edge.To("perms", Perm.Type).
+			Annotations(entsql.Annotation{
+				OnDelete: entsql.Cascade,
+			}),
+		edge.To("deployments", Deployment.Type).
+			Annotations(entsql.Annotation{
+				OnDelete: entsql.Cascade,
+			}),
+		edge.To("chat_callback", ChatCallback.Type).
+			Annotations(entsql.Annotation{
+				OnDelete: entsql.Cascade,
+			}),
 	}
 }

--- a/ent/schema/user.go
+++ b/ent/schema/user.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"entgo.io/ent"
+	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 )
@@ -55,10 +56,19 @@ func (User) Fields() []ent.Field {
 func (User) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.To("chat_user", ChatUser.Type).
-			Unique(),
-		edge.To("perms", Perm.Type),
+			Unique().
+			Annotations(entsql.Annotation{
+				OnDelete: entsql.Cascade,
+			}),
+		edge.To("perms", Perm.Type).
+			Annotations(entsql.Annotation{
+				OnDelete: entsql.Cascade,
+			}),
 		edge.To("deployments", Deployment.Type),
 		edge.To("approvals", Approval.Type),
-		edge.To("notification", Notification.Type),
+		edge.To("notification", Notification.Type).
+			Annotations(entsql.Annotation{
+				OnDelete: entsql.Cascade,
+			}),
 	}
 }


### PR DESCRIPTION
# Contraints

By default, `SET_NULL` is the default constraint to foreign keys, but some entities have different constraints: 

* Repo - all related resources have to be deleted.
* User - Only deployment, approval have to be remained to keep the history, but others have to be deleted.