### PR TITLE
Fix to handle the failure conclusion

### DIFF
--- a/internal/pkg/github/mapper.go
+++ b/internal/pkg/github/mapper.go
@@ -115,8 +115,10 @@ func mapGithubCheckRunToStatus(c *github.CheckRun) *vo.Status {
 
 	if *c.Conclusion == "success" {
 		state = vo.StatusStateSuccess
-	} else {
+	} else if *c.Conclusion == "failure" {
 		state = vo.StatusStateFailure
+	} else {
+		state = vo.StatusStatePending
 	}
 
 	return &vo.Status{


### PR DESCRIPTION
## AS-IS

It displays the `failure` state even though the state is `canceled` or `failure` ([doc](https://docs.github.com/en/rest/reference/checks#create-a-check-run)).