### PR TITLE
Add the detail information to `unlock` command

### DIFF
--- a/internal/server/slack/lock.go
+++ b/internal/server/slack/lock.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/nleeper/goment"
 	"github.com/slack-go/slack"
 	"go.uber.org/zap"
 
@@ -213,11 +214,19 @@ func (s *Slack) handleUnlockCmd(c *gin.Context) {
 func buildUnlockView(callbackID string, locks []*ent.Lock) slack.ModalViewRequest {
 	envs := []*slack.OptionBlockObject{}
 	for _, lock := range locks {
+		var txt string
+		if lock.Edges.User != nil {
+			ca, _ := goment.New(lock.CreatedAt)
+			txt = fmt.Sprintf("%s - Locked by %s %s", lock.Env, lock.Edges.User.Login, ca.FromNow())
+		} else {
+			ca, _ := goment.New(lock.CreatedAt)
+			txt = fmt.Sprintf("%s - Locked %s", lock.Env, ca.FromNow())
+		}
 
 		envs = append(envs, &slack.OptionBlockObject{
 			Text: &slack.TextBlockObject{
 				Type: slack.PlainTextType,
-				Text: lock.Env,
+				Text: txt,
 			},
 			Value: lock.Env,
 		})

--- a/internal/server/slack/rollback.go
+++ b/internal/server/slack/rollback.go
@@ -113,7 +113,7 @@ func buildRollbackView(callbackID string, as []*deploymentAggregation, perms []*
 				strconv.Itoa(d.ID),
 				slack.NewTextBlockObject(
 					slack.PlainTextType,
-					fmt.Sprintf("#%d - %s deployed at %s", d.ID, d.GetShortRef(), created.FromNow()),
+					fmt.Sprintf("#%d - %s deployed %s", d.ID, d.GetShortRef(), created.FromNow()),
 					false, false),
 				nil))
 		}


### PR DESCRIPTION
It provides additional information to users when they unlock the environment. 

<details>
<summary>Example</summary>

![image](https://user-images.githubusercontent.com/17633736/135209240-8129d2fb-0e17-4a0a-8277-141dbe06cae6.png)

</details>