### PR TITLE
Fix the schema type of synched_at of Perm for MySQL

### DIFF
--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -275,7 +275,7 @@ var (
 	PermsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "repo_perm", Type: field.TypeEnum, Enums: []string{"read", "write", "admin"}, Default: "read"},
-		{Name: "synced_at", Type: field.TypeTime, Nullable: true},
+		{Name: "synced_at", Type: field.TypeTime, Nullable: true, SchemaType: map[string]string{"mysql": "timestamp(6)"}},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "repo_id", Type: field.TypeInt64, Nullable: true},

--- a/ent/schema/perm.go
+++ b/ent/schema/perm.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"entgo.io/ent"
+	"entgo.io/ent/dialect"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
@@ -25,7 +26,10 @@ func (Perm) Fields() []ent.Field {
 			).
 			Default("read"),
 		field.Time("synced_at").
-			Optional(),
+			Optional().
+			SchemaType(map[string]string{
+				dialect.MySQL: "timestamp(6)",
+			}),
 		field.Time("created_at").
 			Default(time.Now),
 		field.Time("updated_at").


### PR DESCRIPTION
MySQL has the optional precision value for `timestamp` in the range from 0 to 6, i.e., `000000` to `999999`. But the default timestamp of ent is `timestamp`, which has the precision `0`, and it makes the bug related to #145. 