### PR TITLE
Fix the route for logo static

### DIFF
--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -242,6 +242,7 @@ func NewRouter(c *RouterConfig) *gin.Engine {
 		r.StaticFile("/favicon.ico", "./favicon.ico")
 		r.StaticFile("/manifest.json", "./manifest.json")
 		r.StaticFile("/robots.txt", "./robots.txt")
+		r.StaticFile("/logo192.png", "./logo192.png")
 		r.Static("/static", "./static")
 		if _, err := os.Stat("./index.html"); err == nil {
 			r.NoRoute(w.IndexHTML)


### PR DESCRIPTION
Add the route for the logo to remove the warning message

<details>
<summary>Example</summary>

![image](https://user-images.githubusercontent.com/17633736/136642314-5af00c90-76a5-4005-ab8d-08c5443a18f8.png)

</details>