### PR TITLE
Simplify the logic of deployment.

### DIFF
--- a/internal/interactor/deployment.go
+++ b/internal/interactor/deployment.go
@@ -15,6 +15,16 @@ import (
 )
 
 func (i *Interactor) Deploy(ctx context.Context, u *ent.User, r *ent.Repo, d *ent.Deployment, env *vo.Env) (*ent.Deployment, error) {
+	// Verify the payload is deployable.
+	if locked, err := i.Store.HasLockOfRepoForEnv(ctx, r, d.Env); locked {
+		return nil, e.NewError(
+			e.ErrorCodeDeploymentLocked,
+			err,
+		)
+	} else if err != nil {
+		return nil, err
+	}
+
 	number, err := i.Store.GetNextDeploymentNumberOfRepo(ctx, r)
 	if err != nil {
 		return nil, e.NewError(

--- a/internal/interactor/deployment_test.go
+++ b/internal/interactor/deployment_test.go
@@ -38,10 +38,9 @@ func TestInteractor_Deploy(t *testing.T) {
 				ID: 1,
 			},
 			d: &ent.Deployment{
-				Number: 3,
-				Type:   deployment.TypeCommit,
-				Ref:    "3ee3221",
-				Env:    "local",
+				Type: deployment.TypeCommit,
+				Ref:  "3ee3221",
+				Env:  "local",
 			},
 			e: &vo.Env{},
 		}
@@ -55,6 +54,18 @@ func TestInteractor_Deploy(t *testing.T) {
 			UID = 1000
 		)
 
+		t.Log("MOCK - Check the environment is locked.")
+		store.
+			EXPECT().
+			HasLockOfRepoForEnv(ctx, gomock.Eq(input.r), gomock.Eq(input.d.Env)).
+			Return(false, nil)
+
+		t.Log("MOCK - Get the next deployment number.")
+		store.
+			EXPECT().
+			GetNextDeploymentNumberOfRepo(ctx, gomock.Eq(input.r)).
+			Return(1, nil)
+
 		t.Logf("Returns a new remote deployment with UID = %d", UID)
 		scm.
 			EXPECT().
@@ -67,7 +78,7 @@ func TestInteractor_Deploy(t *testing.T) {
 		store.
 			EXPECT().
 			CreateDeployment(ctx, gomock.Eq(&ent.Deployment{
-				Number: input.d.Number,
+				Number: 1,
 				Type:   input.d.Type,
 				Ref:    input.d.Ref,
 				Env:    input.d.Env,
@@ -95,7 +106,7 @@ func TestInteractor_Deploy(t *testing.T) {
 
 		expected := &ent.Deployment{
 			ID:     ID,
-			Number: input.d.Number,
+			Number: 1,
 			Type:   input.d.Type,
 			Ref:    input.d.Ref,
 			Env:    input.d.Env,
@@ -144,11 +155,23 @@ func TestInteractor_Deploy(t *testing.T) {
 			ID = 1
 		)
 
+		t.Log("MOCK - Check the environment is locked.")
+		store.
+			EXPECT().
+			HasLockOfRepoForEnv(ctx, gomock.Eq(input.r), gomock.Eq(input.d.Env)).
+			Return(false, nil)
+
+		t.Log("MOCK - Get the next deployment number.")
+		store.
+			EXPECT().
+			GetNextDeploymentNumberOfRepo(ctx, gomock.Eq(input.r)).
+			Return(1, nil)
+
 		t.Logf("Check the deployment has configurations of approval.")
 		store.
 			EXPECT().
 			CreateDeployment(ctx, gomock.Eq(&ent.Deployment{
-				Number:                input.d.Number,
+				Number:                1,
 				Type:                  input.d.Type,
 				Ref:                   input.d.Ref,
 				Env:                   input.d.Env,
@@ -173,7 +196,7 @@ func TestInteractor_Deploy(t *testing.T) {
 
 		expected := &ent.Deployment{
 			ID:                    ID,
-			Number:                input.d.Number,
+			Number:                1,
 			Type:                  input.d.Type,
 			Ref:                   input.d.Ref,
 			Env:                   input.d.Env,

--- a/internal/pkg/store/lock.go
+++ b/internal/pkg/store/lock.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gitploy-io/gitploy/ent"
 	"github.com/gitploy-io/gitploy/ent/lock"
+	"github.com/gitploy-io/gitploy/pkg/e"
 )
 
 func (s *Store) ListExpiredLocksLessThanTime(ctx context.Context, t time.Time) ([]*ent.Lock, error) {
@@ -55,7 +56,10 @@ func (s *Store) HasLockOfRepoForEnv(ctx context.Context, r *ent.Repo, env string
 		WithRepo().
 		Count(ctx)
 	if err != nil {
-		return false, err
+		return false, e.NewError(
+			e.ErrorCodeInternalError,
+			err,
+		)
 	}
 
 	return cnt > 0, nil

--- a/internal/server/api/v1/repos/deployment.go
+++ b/internal/server/api/v1/repos/deployment.go
@@ -110,16 +110,6 @@ func (r *Repo) CreateDeployment(c *gin.Context) {
 		return
 	}
 
-	if locked, err := r.i.HasLockOfRepoForEnv(ctx, re, p.Env); locked {
-		r.log.Info("The environment is locked.", zap.String("env", p.Env))
-		gb.ErrorResponse(c, http.StatusUnprocessableEntity, "The environment is locked.")
-		return
-	} else if err != nil {
-		r.log.Error("It has failed to check the lock.", zap.Error(err))
-		gb.ErrorResponse(c, http.StatusInternalServerError, "It has failed to check the lock.")
-		return
-	}
-
 	d, err := r.i.Deploy(ctx, u, re,
 		&ent.Deployment{
 			Type: deployment.Type(p.Type),
@@ -287,16 +277,6 @@ func (r *Repo) RollbackDeployment(c *gin.Context) {
 	if err := cf.GetEnv(d.Env).Eval(&vo.EvalValues{IsRollback: true}); err != nil {
 		r.log.Warn("It has failed to eval variables in the config.", zap.Error(err))
 		gb.ErrorResponse(c, http.StatusUnprocessableEntity, "It has failed to eval variables in the config.")
-		return
-	}
-
-	if locked, err := r.i.HasLockOfRepoForEnv(ctx, re, d.Env); locked {
-		r.log.Info("The environment is locked.", zap.String("env", d.Env))
-		gb.ErrorResponse(c, http.StatusUnprocessableEntity, "The environment is locked.")
-		return
-	} else if err != nil {
-		r.log.Error("It has failed to check the lock.", zap.Error(err))
-		gb.ErrorResponse(c, http.StatusInternalServerError, "It has failed to check the lock.")
 		return
 	}
 

--- a/internal/server/api/v1/repos/deployment_test.go
+++ b/internal/server/api/v1/repos/deployment_test.go
@@ -130,26 +130,13 @@ func TestRepo_CreateDeployment(t *testing.T) {
 				},
 			}, nil)
 
-		t.Log("Check the lock for env.")
-		m.
-			EXPECT().
-			HasLockOfRepoForEnv(gomock.Any(), gomock.AssignableToTypeOf(&ent.Repo{}), input.payload.Env).
-			Return(false, nil)
-
-		t.Log("Return the next deployment number.")
-		m.
-			EXPECT().
-			GetNextDeploymentNumberOfRepo(gomock.Any(), gomock.AssignableToTypeOf(&ent.Repo{})).
-			Return(4, nil)
-
 		t.Log("Deploy with the payload successfully.")
 		m.
 			EXPECT().
 			Deploy(gomock.Any(), gomock.AssignableToTypeOf(&ent.User{}), gomock.AssignableToTypeOf(&ent.Repo{}), gomock.Eq(&ent.Deployment{
-				Number: 4,
-				Type:   deployment.Type(input.payload.Type),
-				Env:    input.payload.Env,
-				Ref:    input.payload.Ref,
+				Type: deployment.Type(input.payload.Type),
+				Env:  input.payload.Env,
+				Ref:  input.payload.Ref,
 			}), gomock.AssignableToTypeOf(&vo.Env{})).
 			Return(&ent.Deployment{}, nil)
 

--- a/internal/server/slack/deploy.go
+++ b/internal/server/slack/deploy.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	linkUnprocessalbeEntity = "https://github.com/gitploy-io/gitploy/discussions/64"
+// linkUnprocessalbeEntity = "https://github.com/gitploy-io/gitploy/discussions/64"
 )
 
 const (

--- a/internal/server/slack/deploy.go
+++ b/internal/server/slack/deploy.go
@@ -310,19 +310,15 @@ func (s *Slack) interactDeploy(c *gin.Context) {
 		return
 	}
 
-	number, err := s.i.GetNextDeploymentNumberOfRepo(ctx, cb.Edges.Repo)
-	if err != nil {
-		s.log.Error("It has failed to get the next deployment number.", zap.Error(err))
-		c.Status(http.StatusInternalServerError)
-		return
-	}
-
-	d, err := s.i.Deploy(ctx, cu.Edges.User, cb.Edges.Repo, &ent.Deployment{
-		Number: number,
-		Type:   deployment.Type(sm.Type),
-		Env:    sm.Env,
-		Ref:    sm.Ref,
-	}, env)
+	d, err := s.i.Deploy(ctx, cu.Edges.User, cb.Edges.Repo,
+		&ent.Deployment{
+			Type: deployment.Type(sm.Type),
+			Env:  sm.Env,
+			Ref:  sm.Ref,
+		},
+		env,
+	)
+	// TODO: Handle to post a message with the error.
 	if ent.IsConstraintError(err) {
 		postBotMessage(cu, "The conflict occurs, please retry.")
 		c.Status(http.StatusOK)

--- a/internal/server/slack/deploy_test.go
+++ b/internal/server/slack/deploy_test.go
@@ -57,26 +57,13 @@ func TestSlack_interactDeploy(t *testing.T) {
 				},
 			}, nil)
 
-		t.Log("Check the lock.")
-		m.
-			EXPECT().
-			HasLockOfRepoForEnv(gomock.Any(), gomock.AssignableToTypeOf(&ent.Repo{}), env).
-			Return(false, nil)
-
-		t.Log("Get the next number of deployment.")
-		m.
-			EXPECT().
-			GetNextDeploymentNumberOfRepo(gomock.Any(), gomock.AssignableToTypeOf(&ent.Repo{})).
-			Return(4, nil)
-
 		t.Log("Deploy with the payload.")
 		m.
 			EXPECT().
 			Deploy(gomock.Any(), gomock.AssignableToTypeOf(&ent.User{}), gomock.AssignableToTypeOf(&ent.Repo{}), &ent.Deployment{
-				Number: 4,
-				Type:   deployment.TypeBranch,
-				Ref:    branch,
-				Env:    env,
+				Type: deployment.TypeBranch,
+				Ref:  branch,
+				Env:  env,
 			}, gomock.AssignableToTypeOf(&vo.Env{})).
 			DoAndReturn(func(ctx context.Context, u *ent.User, r *ent.Repo, d *ent.Deployment, e *vo.Env) (*ent.Deployment, error) {
 				return d, nil

--- a/internal/server/slack/helper.go
+++ b/internal/server/slack/helper.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/gitploy-io/gitploy/ent"
+	"github.com/gitploy-io/gitploy/pkg/e"
 	"github.com/slack-go/slack"
 )
 
@@ -20,6 +21,23 @@ func postResponseMessage(channelID, responseURL, message string) error {
 
 func postBotMessage(cu *ent.ChatUser, message string) error {
 	_, _, _, err := slack.
+		New(cu.BotToken).
+		SendMessage(
+			cu.ID,
+			slack.MsgOptionText(message, false),
+		)
+	return err
+}
+
+func postMessageWithError(cu *ent.ChatUser, err error) error {
+	var message string
+	if ge, ok := err.(*e.Error); ok {
+		message = e.GetMessage(ge.Code)
+	} else {
+		message = err.Error()
+	}
+
+	_, _, _, err = slack.
 		New(cu.BotToken).
 		SendMessage(
 			cu.ID,

--- a/internal/server/slack/rollback.go
+++ b/internal/server/slack/rollback.go
@@ -245,16 +245,6 @@ func (s *Slack) interactRollback(c *gin.Context) {
 		return
 	}
 
-	if locked, err := s.i.HasLockOfRepoForEnv(ctx, cb.Edges.Repo, d.Env); locked {
-		postBotMessage(cu, fmt.Sprintf("The `%s` environment is locked. You should unlock the environment before deploying.", d.Env))
-		c.Status(http.StatusOK)
-		return
-	} else if err != nil {
-		s.log.Error("It has failed to check the lock.", zap.Error(err))
-		c.Status(http.StatusInternalServerError)
-		return
-	}
-
 	d, err = s.i.Deploy(ctx, cu.Edges.User, cb.Edges.Repo, &ent.Deployment{
 		Type:       deployment.Type(d.Type),
 		Ref:        d.Ref,
@@ -262,18 +252,10 @@ func (s *Slack) interactRollback(c *gin.Context) {
 		Env:        d.Env,
 		IsRollback: true,
 	}, env)
-	// TODO: Handle to post a message with the error.
-	if ent.IsConstraintError(err) {
-		postBotMessage(cu, "The conflict occurs, please retry.")
-		c.Status(http.StatusOK)
-		return
-	} else if vo.IsUnprocessibleDeploymentError(err) {
-		postBotMessage(cu, fmt.Sprintf("It is unprocessible entity. (Discussion <%s|#64>)", linkUnprocessalbeEntity))
-		c.Status(http.StatusOK)
-		return
-	} else if err != nil {
+	if err != nil {
 		s.log.Error("It has failed to deploy.", zap.Error(err))
-		c.Status(http.StatusInternalServerError)
+		postMessageWithError(cu, err)
+		c.Status(http.StatusOK)
 		return
 	}
 

--- a/internal/server/slack/rollback.go
+++ b/internal/server/slack/rollback.go
@@ -255,21 +255,14 @@ func (s *Slack) interactRollback(c *gin.Context) {
 		return
 	}
 
-	next, err := s.i.GetNextDeploymentNumberOfRepo(ctx, cb.Edges.Repo)
-	if err != nil {
-		s.log.Error("It has failed to get the next deployment number.", zap.Error(err))
-		c.Status(http.StatusInternalServerError)
-		return
-	}
-
 	d, err = s.i.Deploy(ctx, cu.Edges.User, cb.Edges.Repo, &ent.Deployment{
-		Number:     next,
 		Type:       deployment.Type(d.Type),
 		Ref:        d.Ref,
 		Sha:        d.Sha,
 		Env:        d.Env,
 		IsRollback: true,
 	}, env)
+	// TODO: Handle to post a message with the error.
 	if ent.IsConstraintError(err) {
 		postBotMessage(cu, "The conflict occurs, please retry.")
 		c.Status(http.StatusOK)

--- a/internal/server/slack/rollback_test.go
+++ b/internal/server/slack/rollback_test.go
@@ -61,23 +61,10 @@ func TestSlack_interactRollback(t *testing.T) {
 				},
 			}, nil)
 
-		t.Log("Check the lock.")
-		m.
-			EXPECT().
-			HasLockOfRepoForEnv(gomock.Any(), gomock.AssignableToTypeOf(&ent.Repo{}), "prod").
-			Return(false, nil)
-
-		t.Log("Get the next number of deployment.")
-		m.
-			EXPECT().
-			GetNextDeploymentNumberOfRepo(gomock.Any(), gomock.AssignableToTypeOf(&ent.Repo{})).
-			Return(4, nil)
-
 		t.Log("Roll back with the returned deployment.")
 		m.
 			EXPECT().
 			Deploy(gomock.Any(), gomock.AssignableToTypeOf(&ent.User{}), gomock.AssignableToTypeOf(&ent.Repo{}), &ent.Deployment{
-				Number:     4,
 				Type:       deployment.TypeCommit,
 				Ref:        "main",
 				Sha:        "ee411aa",

--- a/pkg/e/code.go
+++ b/pkg/e/code.go
@@ -38,7 +38,7 @@ func NewError(code ErrorCode, wrap error) *Error {
 }
 
 func (e *Error) Error() string {
-	return fmt.Sprintf("code: %s, message: %s : %s", e.Code, GetMessage(e.Code), e.Wrap)
+	return fmt.Sprintf("code: %s, message: %s, wrap: %s", e.Code, GetMessage(e.Code), e.Wrap)
 }
 
 func (e *Error) Unwrap() error {

--- a/pkg/e/code.go
+++ b/pkg/e/code.go
@@ -5,8 +5,12 @@ import (
 )
 
 const (
-	// ErrorCodeMergeConflict is that the ref can't be merged into the main branch.
-	ErrorCodeMergeConflict ErrorCode = "merge_conflict"
+	// ErrorCodeDeploymentConflict is the deployment number is conflicted.
+	ErrorCodeDeploymentConflict ErrorCode = "deployment_conflict"
+	// ErrorCodeDeploymentUndeployable is that the merge conflict occurs or a commit status has failed.
+	ErrorCodeDeploymentUndeployable ErrorCode = "deployment_undeployable"
+	// ErrorCodeDeploymentInvalid is the payload is invalid.
+	ErrorCodeDeploymentInvalid ErrorCode = "deployment_invalid"
 
 	// ErrorCodeLicenseDecode is that the license.
 	ErrorCodeLicenseDecode ErrorCode = "license_decode"

--- a/pkg/e/code.go
+++ b/pkg/e/code.go
@@ -7,10 +7,12 @@ import (
 const (
 	// ErrorCodeDeploymentConflict is the deployment number is conflicted.
 	ErrorCodeDeploymentConflict ErrorCode = "deployment_conflict"
-	// ErrorCodeDeploymentUndeployable is that the merge conflict occurs or a commit status has failed.
-	ErrorCodeDeploymentUndeployable ErrorCode = "deployment_undeployable"
 	// ErrorCodeDeploymentInvalid is the payload is invalid.
 	ErrorCodeDeploymentInvalid ErrorCode = "deployment_invalid"
+	// ErrorCodeDeploymentLocked is when the environment is locked.
+	ErrorCodeDeploymentLocked ErrorCode = "deployment_locked"
+	// ErrorCodeDeploymentUndeployable is that the merge conflict occurs or a commit status has failed.
+	ErrorCodeDeploymentUndeployable ErrorCode = "deployment_undeployable"
 
 	// ErrorCodeLicenseDecode is that the license.
 	ErrorCodeLicenseDecode ErrorCode = "license_decode"

--- a/pkg/e/trans.go
+++ b/pkg/e/trans.go
@@ -3,9 +3,11 @@ package e
 import "net/http"
 
 var messages = map[ErrorCode]string{
-	ErrorCodeMergeConflict: "There is merge conflict.",
-	ErrorCodeLicenseDecode: "Decoding the license is failed.",
-	ErrorCodeInternalError: "Server internal error.",
+	ErrorCodeDeploymentConflict:     "The conflict occurs, please retry.",
+	ErrorCodeDeploymentUndeployable: "There is merge conflict or a commit status check failed.",
+	ErrorCodeDeploymentInvalid:      "The validation has failed.",
+	ErrorCodeLicenseDecode:          "Decoding the license is failed.",
+	ErrorCodeInternalError:          "Server internal error.",
 }
 
 func GetMessage(code ErrorCode) string {
@@ -18,9 +20,11 @@ func GetMessage(code ErrorCode) string {
 }
 
 var httpCodes = map[ErrorCode]int{
-	ErrorCodeMergeConflict: http.StatusUnprocessableEntity,
-	ErrorCodeLicenseDecode: http.StatusUnprocessableEntity,
-	ErrorCodeInternalError: http.StatusInternalServerError,
+	ErrorCodeDeploymentConflict:     http.StatusUnprocessableEntity,
+	ErrorCodeDeploymentUndeployable: http.StatusUnprocessableEntity,
+	ErrorCodeDeploymentInvalid:      http.StatusUnprocessableEntity,
+	ErrorCodeLicenseDecode:          http.StatusUnprocessableEntity,
+	ErrorCodeInternalError:          http.StatusInternalServerError,
 }
 
 func GetHttpCode(code ErrorCode) int {

--- a/pkg/e/trans.go
+++ b/pkg/e/trans.go
@@ -4,8 +4,9 @@ import "net/http"
 
 var messages = map[ErrorCode]string{
 	ErrorCodeDeploymentConflict:     "The conflict occurs, please retry.",
-	ErrorCodeDeploymentUndeployable: "There is merge conflict or a commit status check failed.",
 	ErrorCodeDeploymentInvalid:      "The validation has failed.",
+	ErrorCodeDeploymentLocked:       "The environment is locked.",
+	ErrorCodeDeploymentUndeployable: "There is merge conflict or a commit status check failed.",
 	ErrorCodeLicenseDecode:          "Decoding the license is failed.",
 	ErrorCodeInternalError:          "Server internal error.",
 }
@@ -21,8 +22,9 @@ func GetMessage(code ErrorCode) string {
 
 var httpCodes = map[ErrorCode]int{
 	ErrorCodeDeploymentConflict:     http.StatusUnprocessableEntity,
-	ErrorCodeDeploymentUndeployable: http.StatusUnprocessableEntity,
 	ErrorCodeDeploymentInvalid:      http.StatusUnprocessableEntity,
+	ErrorCodeDeploymentLocked:       http.StatusUnprocessableEntity,
+	ErrorCodeDeploymentUndeployable: http.StatusUnprocessableEntity,
 	ErrorCodeLicenseDecode:          http.StatusUnprocessableEntity,
 	ErrorCodeInternalError:          http.StatusInternalServerError,
 }


### PR DESCRIPTION
Simplifying the deployment API moves validations into the `interactor` package. We need to migrate business logic into the `interactor` gradually.