### PR TITLE
Add 'deployable_ref' field for the validation of ref

### DIFF
--- a/docs/references/deploy.yml.md
+++ b/docs/references/deploy.yml.md
@@ -17,7 +17,8 @@ Field                    |Type                     |Required  |Description
 `required_contexts`      |*[]string*               |`false`   |This field allows you to specify a subset of contexts that must be success. 
 `payload`                |*object* or *string*     |`false`   |This field is JSON payload with extra information about the deployment. 
 `production_environment` |*boolean*                |`false`   |This field specifies whether this runtime environment is production or not.
-`review`               |*[Review](#review)*  |`false`   |This field configures review.
+`deployable_ref`         |*string*                 |`false`   |This field specifies which the ref(branch, SHA, tag) is deployable or not. It supports the regular expression, [re2](https://github.com/google/re2/wiki/Syntax) by Google, to match the ref. 
+`review`                 |*[Review](#review)*      |`false`   |This field configures review.
 
 ## Review
 

--- a/internal/interactor/deployment_test.go
+++ b/internal/interactor/deployment_test.go
@@ -24,6 +24,34 @@ func newMockInteractor(store Store, scm SCM) *Interactor {
 	}
 }
 
+func TestInteractor_IsApproved(t *testing.T) {
+	t.Run("Return false when a review is rejected.", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		store := mock.NewMockStore(ctrl)
+		scm := mock.NewMockSCM(ctrl)
+
+		t.Log("Return various status reviews")
+		store.
+			EXPECT().
+			ListReviews(gomock.Any(), gomock.AssignableToTypeOf(&ent.Deployment{})).
+			Return([]*ent.Review{
+				{
+					Status: review.StatusPending,
+				},
+				{
+					Status: review.StatusRejected,
+				},
+			}, nil)
+
+		i := newMockInteractor(store, scm)
+
+		expected := false
+		if ret := i.IsApproved(context.Background(), &ent.Deployment{}); ret != expected {
+			t.Fatalf("IsApproved = %v, wanted %v", ret, expected)
+		}
+	})
+}
+
 func TestInteractor_Deploy(t *testing.T) {
 	ctx := gomock.Any()
 

--- a/pkg/e/code.go
+++ b/pkg/e/code.go
@@ -13,7 +13,7 @@ const (
 
 	// ErrorCodeDeploymentConflict is the deployment number is conflicted.
 	ErrorCodeDeploymentConflict ErrorCode = "deployment_conflict"
-	// ErrorCodeDeploymentInvalid is the payload is invalid.
+	// ErrorCodeDeploymentInvalid is the payload is invalid when it posts a remote deployment.
 	ErrorCodeDeploymentInvalid ErrorCode = "deployment_invalid"
 	// ErrorCodeDeploymentLocked is when the environment is locked.
 	ErrorCodeDeploymentLocked ErrorCode = "deployment_locked"

--- a/pkg/e/code.go
+++ b/pkg/e/code.go
@@ -8,6 +8,8 @@ import (
 const (
 	// ErrorCodeConfigParseError is that an error occurs when it parse the file.
 	ErrorCodeConfigParseError ErrorCode = "config_parse_error"
+	// ErrorCodeConfigRegexpError is the regexp(re2) is invalid.
+	ErrorCodeConfigRegexpError ErrorCode = "config_regexp_error"
 
 	// ErrorCodeDeploymentConflict is the deployment number is conflicted.
 	ErrorCodeDeploymentConflict ErrorCode = "deployment_conflict"

--- a/pkg/e/trans.go
+++ b/pkg/e/trans.go
@@ -4,6 +4,7 @@ import "net/http"
 
 var messages = map[ErrorCode]string{
 	ErrorCodeConfigParseError:        "The configuration is invalid.",
+	ErrorCodeConfigRegexpError:       "The regexp is invalid.",
 	ErrorCodeDeploymentConflict:      "The conflict occurs, please retry.",
 	ErrorCodeDeploymentInvalid:       "The validation has failed.",
 	ErrorCodeDeploymentLocked:        "The environment is locked.",
@@ -30,6 +31,7 @@ func GetMessage(code ErrorCode) string {
 
 var httpCodes = map[ErrorCode]int{
 	ErrorCodeConfigParseError:        http.StatusUnprocessableEntity,
+	ErrorCodeConfigRegexpError:       http.StatusUnprocessableEntity,
 	ErrorCodeDeploymentConflict:      http.StatusUnprocessableEntity,
 	ErrorCodeDeploymentInvalid:       http.StatusUnprocessableEntity,
 	ErrorCodeDeploymentLocked:        http.StatusUnprocessableEntity,

--- a/vo/config.go
+++ b/vo/config.go
@@ -48,7 +48,9 @@ const (
 )
 
 const (
-	defaultDeployTask   = "deploy"
+	// defaultDeployTask is the value of the 'GITPLOY_DEPLOY_TASK' variable.
+	defaultDeployTask = "deploy"
+	// defaultRollbackTask is the value of the 'GITPLOY_ROLLBACK_TASK' variable.
 	defaultRollbackTask = "rollback"
 )
 
@@ -80,10 +82,12 @@ func (c *Config) GetEnv(name string) *Env {
 	return nil
 }
 
+// IsProductionEnvironment check whether the environment is production or not.
 func (e *Env) IsProductionEnvironment() bool {
 	return e.ProductionEnvironment != nil && *e.ProductionEnvironment
 }
 
+// HasReview check whether the review is enabled or not.
 func (e *Env) HasReview() bool {
 	return e.Review != nil && e.Review.Enabled
 }

--- a/vo/config_test.go
+++ b/vo/config_test.go
@@ -112,6 +112,54 @@ func TestEnv_IsProductionEnvironment(t *testing.T) {
 	})
 }
 
+func TestEnv_IsDeployableRef(t *testing.T) {
+	t.Run("Return true when 'deployable_ref' is not defined.", func(t *testing.T) {
+		e := &Env{}
+
+		ret, err := e.IsDeployableRef("")
+		if err != nil {
+			t.Fatalf("IsDeployableRef returns an error: %s", err)
+		}
+
+		expected := true
+		if ret != expected {
+			t.Fatalf("IsDeployableRef = %v, wanted %v", ret, expected)
+		}
+	})
+
+	t.Run("Return true when 'deployable_ref' is matched.", func(t *testing.T) {
+		e := &Env{
+			DeployableRef: pointer.ToString("main"),
+		}
+
+		ret, err := e.IsDeployableRef("main")
+		if err != nil {
+			t.Fatalf("IsDeployableRef returns an error: %s", err)
+		}
+
+		expected := true
+		if ret != expected {
+			t.Fatalf("IsDeployableRef = %v, wanted %v", ret, expected)
+		}
+	})
+
+	t.Run("Return false when 'deployable_ref' is not matched.", func(t *testing.T) {
+		e := &Env{
+			DeployableRef: pointer.ToString("main"),
+		}
+
+		ret, err := e.IsDeployableRef("branch")
+		if err != nil {
+			t.Fatalf("IsDeployableRef returns an error: %s", err)
+		}
+
+		expected := false
+		if ret != expected {
+			t.Fatalf("IsDeployableRef = %v, wanted %v", ret, expected)
+		}
+	})
+}
+
 func TestEnv_Eval(t *testing.T) {
 	t.Run("eval the task.", func(t *testing.T) {
 		cs := []struct {


### PR DESCRIPTION
Add `deployable_ref` field to the configuration to validate the ref which is deployable or not. If it is not matched, it returns an unprocessable entity error.

![스크린샷 2021-11-19 오전 3 42 11](https://user-images.githubusercontent.com/17633736/142477741-8f8d27ba-d6c9-428f-9e3f-747f4f43250c.png)


