### PR TITLE
Add a new tab meun 'Read Doc'

### DIFF
--- a/ui/src/views/Main.tsx
+++ b/ui/src/views/Main.tsx
@@ -131,15 +131,14 @@ export default function Main(props: any) {
                             <Dropdown overlay={
                                 <Menu>
                                     <Menu.Item key="0">
-                                        <a href="/settings">
-                                            Settings
-                                        </a>
+                                        <a href="/settings">Settings</a>
                                     </Menu.Item>
                                     <Menu.Divider />
                                     <Menu.Item key="1">
-                                        <a href="/signout">
-                                            Sign out
-                                        </a>
+                                        <a href="https://docs.gitploy.io/" target="_blank">Read Doc</a>
+                                    </Menu.Item>
+                                    <Menu.Item key="2">
+                                        <a href="/signout">Sign out</a>
                                     </Menu.Item>
                                 </Menu> 
                             }>


### PR DESCRIPTION
Add a new handy link, `Read Doc` for the documentation.

![스크린샷 2021-11-19 오전 4 18 31](https://user-images.githubusercontent.com/17633736/142482443-0a4fc84a-7fff-49c3-915e-46755c6fdbe8.png)


