### PR TITLE
Upgrade the React V5

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,7 +8,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@craco/craco": "^6.1.2",
-        "@reduxjs/toolkit": "^1.5.1",
+        "@reduxjs/toolkit": "^1.6.2",
         "@testing-library/jest-dom": "^5.12.0",
         "@testing-library/react": "^11.2.7",
         "@testing-library/user-event": "^12.8.3",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -12,11 +12,6 @@
         "@testing-library/jest-dom": "^5.12.0",
         "@testing-library/react": "^11.2.7",
         "@testing-library/user-event": "^12.8.3",
-        "@types/jest": "^26.0.23",
-        "@types/lodash.debounce": "^4.0.6",
-        "@types/node": "^12.20.13",
-        "@types/react": "^17.0.8",
-        "@types/react-dom": "^17.0.5",
         "antd": "^4.16.1",
         "craco-less": "^1.17.1",
         "http-status-codes": "^2.1.4",
@@ -31,6 +26,11 @@
         "web-vitals": "^1.1.2"
       },
       "devDependencies": {
+        "@types/jest": "^26.0.23",
+        "@types/lodash.debounce": "^4.0.6",
+        "@types/node": "^12.20.13",
+        "@types/react": "^17.0.8",
+        "@types/react-dom": "^17.0.5",
         "@types/react-helmet": "^6.1.4",
         "@types/react-router-dom": "^5.1.7",
         "@typescript-eslint/eslint-plugin": "^4.28.4",
@@ -2840,12 +2840,14 @@
     "node_modules/@types/lodash": {
       "version": "4.14.171",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.171.tgz",
-      "integrity": "sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg=="
+      "integrity": "sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg==",
+      "dev": true
     },
     "node_modules/@types/lodash.debounce": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz",
       "integrity": "sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==",
+      "dev": true,
       "dependencies": {
         "@types/lodash": "*"
       }
@@ -2899,6 +2901,7 @@
       "version": "17.0.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.5.tgz",
       "integrity": "sha512-ikqukEhH4H9gr4iJCmQVNzTB307kROe3XFfHAOTxOXPOw7lAoEXnM5KWTkzeANGL5Ce6ABfiMl/zJBYNi7ObmQ==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -19308,6 +19311,7 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -19752,6 +19756,7 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -23409,12 +23414,14 @@
     "@types/lodash": {
       "version": "4.14.171",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.171.tgz",
-      "integrity": "sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg=="
+      "integrity": "sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg==",
+      "dev": true
     },
     "@types/lodash.debounce": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz",
       "integrity": "sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==",
+      "dev": true,
       "requires": {
         "@types/lodash": "*"
       }
@@ -23468,6 +23475,7 @@
       "version": "17.0.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.5.tgz",
       "integrity": "sha512-ikqukEhH4H9gr4iJCmQVNzTB307kROe3XFfHAOTxOXPOw7lAoEXnM5KWTkzeANGL5Ce6ABfiMl/zJBYNi7ObmQ==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@craco/craco": "^6.1.2",
-    "@reduxjs/toolkit": "^1.5.1",
+    "@reduxjs/toolkit": "^1.6.2",
     "@testing-library/jest-dom": "^5.12.0",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",
@@ -47,11 +47,11 @@
     ]
   },
   "devDependencies": {
+    "@types/jest": "^26.0.23",
     "@types/lodash.debounce": "^4.0.6",
     "@types/node": "^12.20.13",
     "@types/react": "^17.0.8",
     "@types/react-dom": "^17.0.5",
-    "@types/jest": "^26.0.23",
     "@types/react-helmet": "^6.1.4",
     "@types/react-router-dom": "^5.1.7",
     "@typescript-eslint/eslint-plugin": "^4.28.4",


### PR DESCRIPTION
We should upgrade `react-script` to resolve dependencies alerts. The next `5.0.0` is WIP ([ref](https://openbase.com/js/react-scripts/versions)).

## History

* Upgrade `@reduxjs/toolkit@1.6.2`

Related [link](https://github.com/gitploy-io/gitploy/security/dependabot?q=is%3Aclosed)