### PR TITLE
Add repo command to access `Repo` entities

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -26,6 +26,10 @@ func main() {
 				Usage:    "The authorization token.",
 				EnvVars:  []string{"GITPLOY_TOKEN"},
 			},
+			&cli.StringFlag{
+				Name:  "query",
+				Usage: "A GJSON query to use in filtering the response data",
+			},
 		},
 		Commands: []*cli.Command{
 			repoCommand,

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -27,7 +27,9 @@ func main() {
 				EnvVars:  []string{"GITPLOY_TOKEN"},
 			},
 		},
-		Commands: []*cli.Command{},
+		Commands: []*cli.Command{
+			repoCommand,
+		},
 	}
 
 	err := app.Run(os.Args)

--- a/cmd/cli/repo.go
+++ b/cmd/cli/repo.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/gitploy-io/gitploy/model/ent"
+	"github.com/gitploy-io/gitploy/pkg/api"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	repoCommand *cli.Command = &cli.Command{
+		Name:  "repo",
+		Usage: "Manage repos.",
+		Subcommands: []*cli.Command{
+			repoListCommand,
+		},
+	}
+
+	repoListCommand = &cli.Command{
+		Name:    "list",
+		Aliases: []string{"ls"},
+		Usage:   "Show own repositories.",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "all",
+				Usage: "Show all repositories.",
+			},
+			&cli.IntFlag{
+				Name:  "page",
+				Value: 1,
+				Usage: "The page of list.",
+			},
+			&cli.IntFlag{
+				Name:  "per-page",
+				Value: 30,
+				Usage: "The item count per page.",
+			},
+		},
+		Action: func(cli *cli.Context) error {
+			c := buildClient(cli)
+
+			var (
+				repos []*ent.Repo
+				err   error
+			)
+
+			if cli.Bool("all") {
+				if repos, err = c.Repo.ListAll(cli.Context); err != nil {
+					return err
+				}
+			} else {
+				if repos, err = c.Repo.List(cli.Context, api.RepoListOptions{
+					ListOptions: api.ListOptions{Page: cli.Int("page"), PerPage: cli.Int("per-page")},
+				}); err != nil {
+					return err
+				}
+			}
+
+			// TODO: Enhance output format.
+			for _, repo := range repos {
+				fmt.Printf("%s/%s\n", repo.Namespace, repo.Name)
+			}
+
+			return nil
+		},
+	}
+)

--- a/cmd/cli/repo.go
+++ b/cmd/cli/repo.go
@@ -9,5 +9,6 @@ var repoCommand *cli.Command = &cli.Command{
 	Usage: "Manage repos.",
 	Subcommands: []*cli.Command{
 		repoListCommand,
+		repoGetCommand,
 	},
 }

--- a/cmd/cli/repo.go
+++ b/cmd/cli/repo.go
@@ -1,68 +1,13 @@
 package main
 
 import (
-	"fmt"
-
-	"github.com/gitploy-io/gitploy/model/ent"
-	"github.com/gitploy-io/gitploy/pkg/api"
 	"github.com/urfave/cli/v2"
 )
 
-var (
-	repoCommand *cli.Command = &cli.Command{
-		Name:  "repo",
-		Usage: "Manage repos.",
-		Subcommands: []*cli.Command{
-			repoListCommand,
-		},
-	}
-
-	repoListCommand = &cli.Command{
-		Name:    "list",
-		Aliases: []string{"ls"},
-		Usage:   "Show own repositories.",
-		Flags: []cli.Flag{
-			&cli.BoolFlag{
-				Name:  "all",
-				Usage: "Show all repositories.",
-			},
-			&cli.IntFlag{
-				Name:  "page",
-				Value: 1,
-				Usage: "The page of list.",
-			},
-			&cli.IntFlag{
-				Name:  "per-page",
-				Value: 30,
-				Usage: "The item count per page.",
-			},
-		},
-		Action: func(cli *cli.Context) error {
-			c := buildClient(cli)
-
-			var (
-				repos []*ent.Repo
-				err   error
-			)
-
-			if cli.Bool("all") {
-				if repos, err = c.Repo.ListAll(cli.Context); err != nil {
-					return err
-				}
-			} else {
-				if repos, err = c.Repo.List(cli.Context, api.RepoListOptions{
-					ListOptions: api.ListOptions{Page: cli.Int("page"), PerPage: cli.Int("per-page")},
-				}); err != nil {
-					return err
-				}
-			}
-
-			// TODO: Enhance output format.
-			for _, repo := range repos {
-				fmt.Printf("%s/%s\n", repo.Namespace, repo.Name)
-			}
-
-			return nil
-		},
-	}
-)
+var repoCommand *cli.Command = &cli.Command{
+	Name:  "repo",
+	Usage: "Manage repos.",
+	Subcommands: []*cli.Command{
+		repoListCommand,
+	},
+}

--- a/cmd/cli/repo.go
+++ b/cmd/cli/repo.go
@@ -10,5 +10,6 @@ var repoCommand *cli.Command = &cli.Command{
 	Subcommands: []*cli.Command{
 		repoListCommand,
 		repoGetCommand,
+		repoUpdateCommand,
 	},
 }

--- a/cmd/cli/repo_get.go
+++ b/cmd/cli/repo_get.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/tidwall/gjson"
+	"github.com/urfave/cli/v2"
+)
+
+var repoGetCommand = &cli.Command{
+	Name:      "get",
+	Usage:     "Show the repository.",
+	ArgsUsage: "<owner>/<repo>",
+	Action: func(cli *cli.Context) error {
+		ns, n, err := splitFullName(cli.Args().First())
+		if err != nil {
+			return err
+		}
+
+		c := buildClient(cli)
+		repo, err := c.Repo.Get(cli.Context, ns, n)
+		if err != nil {
+			return err
+		}
+
+		output, err := json.MarshalIndent(repo, "", "  ")
+		if err != nil {
+			return fmt.Errorf("Failed to marshal: %w", err)
+		}
+
+		if q := cli.String("query"); q != "" {
+			fmt.Println(gjson.GetBytes(output, q))
+			return nil
+		}
+
+		fmt.Println(string(output))
+		return nil
+	},
+}

--- a/cmd/cli/repo_list.go
+++ b/cmd/cli/repo_list.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/tidwall/gjson"
+	"github.com/urfave/cli/v2"
+
+	"github.com/gitploy-io/gitploy/model/ent"
+	"github.com/gitploy-io/gitploy/pkg/api"
+)
+
+var repoListCommand = &cli.Command{
+	Name:    "list",
+	Aliases: []string{"ls"},
+	Usage:   "Show own repositories.",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "all",
+			Usage: "Show all repositories.",
+		},
+		&cli.IntFlag{
+			Name:  "page",
+			Value: 1,
+			Usage: "The page of list.",
+		},
+		&cli.IntFlag{
+			Name:  "per-page",
+			Value: 30,
+			Usage: "The item count per page.",
+		},
+	},
+	Action: func(cli *cli.Context) error {
+		c := buildClient(cli)
+
+		var (
+			repos []*ent.Repo
+			err   error
+		)
+
+		if cli.Bool("all") {
+			if repos, err = c.Repo.ListAll(cli.Context); err != nil {
+				return err
+			}
+		} else {
+			if repos, err = c.Repo.List(cli.Context, api.RepoListOptions{
+				ListOptions: api.ListOptions{Page: cli.Int("page"), PerPage: cli.Int("per-page")},
+			}); err != nil {
+				return err
+			}
+		}
+
+		output, err := json.MarshalIndent(repos, "", "  ")
+		if err != nil {
+			return fmt.Errorf("Failed to marshal: %w", err)
+		}
+
+		if q := cli.String("query"); q != "" {
+			fmt.Println(gjson.GetBytes(output, q))
+			return nil
+		}
+
+		fmt.Println(string(output))
+		return nil
+	},
+}

--- a/cmd/cli/repo_update.go
+++ b/cmd/cli/repo_update.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/AlekSi/pointer"
 	"github.com/gitploy-io/gitploy/pkg/api"
@@ -20,6 +21,11 @@ var repoUpdateCommand = &cli.Command{
 			Aliases: []string{"C"},
 			Usage:   "The path of configuration file.",
 		},
+		&cli.StringFlag{
+			Name:    "active",
+			Aliases: []string{"A"},
+			Usage:   "Activate or deactivate the repository. Ex 'true', 'false'",
+		},
 	},
 	Action: func(cli *cli.Context) error {
 		ns, n, err := splitFullName(cli.Args().First())
@@ -31,6 +37,15 @@ var repoUpdateCommand = &cli.Command{
 		req := api.RepoUpdateRequest{}
 		if config := cli.String("config"); config != "" {
 			req.ConfigPath = pointer.ToString(config)
+		}
+
+		if active := cli.String("active"); active != "" {
+			b, err := strconv.ParseBool(active)
+			if err != nil {
+				return fmt.Errorf("'%s' is invalid format: %w", active, err)
+			}
+
+			req.Active = pointer.ToBool(b)
 		}
 
 		c := buildClient(cli)

--- a/cmd/cli/repo_update.go
+++ b/cmd/cli/repo_update.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/AlekSi/pointer"
+	"github.com/gitploy-io/gitploy/pkg/api"
+	"github.com/tidwall/gjson"
+	"github.com/urfave/cli/v2"
+)
+
+var repoUpdateCommand = &cli.Command{
+	Name:      "update",
+	Usage:     "Update the repository.",
+	ArgsUsage: "<owner>/<repo>",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "config",
+			Aliases: []string{"C"},
+			Usage:   "The path of configuration file.",
+		},
+	},
+	Action: func(cli *cli.Context) error {
+		ns, n, err := splitFullName(cli.Args().First())
+		if err != nil {
+			return err
+		}
+
+		// Build the request body.
+		req := api.RepoUpdateRequest{}
+		if config := cli.String("config"); config != "" {
+			req.ConfigPath = pointer.ToString(config)
+		}
+
+		c := buildClient(cli)
+		repo, err := c.Repo.Update(cli.Context, ns, n, req)
+		if err != nil {
+			return err
+		}
+
+		output, err := json.MarshalIndent(repo, "", "  ")
+		if err != nil {
+			return fmt.Errorf("Failed to marshal: %w", err)
+		}
+
+		if q := cli.String("query"); q != "" {
+			fmt.Println(gjson.GetBytes(output, q))
+			return nil
+		}
+
+		fmt.Println(string(output))
+		return nil
+	},
+}

--- a/cmd/cli/shared.go
+++ b/cmd/cli/shared.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"github.com/urfave/cli/v2"
+	"golang.org/x/oauth2"
+
+	"github.com/gitploy-io/gitploy/pkg/api"
+)
+
+func buildClient(cli *cli.Context) *api.Client {
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: cli.String("token")},
+	)
+	tc := oauth2.NewClient(cli.Context, ts)
+
+	return api.NewClient(cli.String("host"), tc)
+}

--- a/cmd/cli/shared.go
+++ b/cmd/cli/shared.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/urfave/cli/v2"
 	"golang.org/x/oauth2"
 
 	"github.com/gitploy-io/gitploy/pkg/api"
 )
 
+// buildClient returns a client to interact with a server.
 func buildClient(cli *cli.Context) *api.Client {
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: cli.String("token")},
@@ -14,4 +18,13 @@ func buildClient(cli *cli.Context) *api.Client {
 	tc := oauth2.NewClient(cli.Context, ts)
 
 	return api.NewClient(cli.String("host"), tc)
+}
+
+func splitFullName(name string) (string, string, error) {
+	ss := strings.Split(name, "/")
+	if len(ss) != 2 {
+		return "", "", fmt.Errorf("'%s' is invalid format", name)
+	}
+
+	return ss[0], ss[1], nil
 }

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,9 @@ require (
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect
 	github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	github.com/tidwall/gjson v1.13.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/ugorji/go/codec v1.2.6 // indirect
 	github.com/urfave/cli/v2 v2.3.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -446,6 +446,12 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/tidwall/gjson v1.13.0 h1:3TFY9yxOQShrvmjdM76K+jc66zJeT6D3/VFFYCGQf7M=
+github.com/tidwall/gjson v1.13.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go v1.2.6 h1:tGiWC9HENWE2tqYycIqFTNorMmFRVhNwCpDOpWqnk8E=

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -33,7 +33,7 @@ type (
 	}
 
 	service struct {
-		client *client
+		*client
 	}
 
 	ErrorResponse struct {

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -20,6 +20,7 @@ type (
 		common *client
 
 		// Services used for talking to different parts of the Gitploy API.
+		Repo *RepoService
 	}
 
 	client struct {
@@ -31,9 +32,9 @@ type (
 		BaseURL *url.URL
 	}
 
-	// service struct {
-	// 	client *client
-	// }
+	service struct {
+		client *client
+	}
 
 	ErrorResponse struct {
 		Code    string `json:"code"`
@@ -51,6 +52,8 @@ func NewClient(host string, httpClient *http.Client) *Client {
 	c := &Client{
 		common: &client{httpClient: httpClient, BaseURL: baseURL},
 	}
+
+	c.Repo = &RepoService{client: c.common}
 
 	return c
 }

--- a/pkg/api/repo.go
+++ b/pkg/api/repo.go
@@ -14,7 +14,7 @@ type (
 		ListOptions
 	}
 
-	RepoUpdateOptions struct {
+	RepoUpdateRequest struct {
 		ConfigPath *string `json:"config_path,omitemtpy"`
 		Active     *bool   `json:"active,omitemtpy"`
 	}
@@ -88,7 +88,7 @@ func (s *RepoService) Get(ctx context.Context, namespace, name string) (*ent.Rep
 	return repo, nil
 }
 
-func (s *RepoService) Update(ctx context.Context, namespace, name string, options RepoUpdateOptions) (*ent.Repo, error) {
+func (s *RepoService) Update(ctx context.Context, namespace, name string, options RepoUpdateRequest) (*ent.Repo, error) {
 	req, err := s.client.NewRequest(
 		"PATCH",
 		fmt.Sprintf("api/v1/repos/%s/%s", namespace, name),

--- a/pkg/api/repo.go
+++ b/pkg/api/repo.go
@@ -1,0 +1,107 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gitploy-io/gitploy/model/ent"
+)
+
+type (
+	RepoService service
+
+	RepoListOptions struct {
+		ListOptions
+	}
+
+	RepoUpdateOptions struct {
+		ConfigPath *string `json:"config_path,omitemtpy"`
+		Active     *bool   `json:"active,omitemtpy"`
+	}
+)
+
+// ListAll returns all repositories.
+func (s *RepoService) ListAll(ctx context.Context) ([]*ent.Repo, error) {
+	// Max value for 'perPage'.
+	const perPage = 100
+
+	repos := make([]*ent.Repo, 0)
+	page := 1
+
+	for true {
+		rs, err := s.List(ctx, RepoListOptions{
+			ListOptions{
+				Page:    page,
+				PerPage: perPage,
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		repos = append(repos, rs...)
+
+		// Met the end of pages.
+		if len(rs) < perPage {
+			break
+		}
+
+		page = page + 1
+	}
+
+	return repos, nil
+}
+
+// List returns repositories which are on the page.
+func (s *RepoService) List(ctx context.Context, options RepoListOptions) ([]*ent.Repo, error) {
+	req, err := s.client.NewRequest(
+		"GET",
+		fmt.Sprintf("api/v1/repos?page=%d&per_page=%d", options.Page, options.PerPage),
+		nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var repos []*ent.Repo
+	if err := s.client.Do(ctx, req, &repos); err != nil {
+		return nil, err
+	}
+
+	return repos, nil
+}
+
+// Get returns the repository.
+func (s *RepoService) Get(ctx context.Context, namespace, name string) (*ent.Repo, error) {
+	req, err := s.client.NewRequest(
+		"GET",
+		fmt.Sprintf("api/v1/repos/%s/%s", namespace, name),
+		nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var repo *ent.Repo
+	if err := s.client.Do(ctx, req, &repo); err != nil {
+		return nil, err
+	}
+
+	return repo, nil
+}
+
+func (s *RepoService) Update(ctx context.Context, namespace, name string, options RepoUpdateOptions) (*ent.Repo, error) {
+	req, err := s.client.NewRequest(
+		"PATCH",
+		fmt.Sprintf("api/v1/repos/%s/%s", namespace, name),
+		options,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var repo *ent.Repo
+	if err := s.client.Do(ctx, req, &repo); err != nil {
+		return nil, err
+	}
+
+	return repo, nil
+}

--- a/pkg/api/repo.go
+++ b/pkg/api/repo.go
@@ -15,8 +15,8 @@ type (
 	}
 
 	RepoUpdateRequest struct {
-		ConfigPath *string `json:"config_path,omitemtpy"`
-		Active     *bool   `json:"active,omitemtpy"`
+		ConfigPath *string `json:"config_path,omitempty"`
+		Active     *bool   `json:"active,omitempty"`
 	}
 )
 
@@ -28,7 +28,7 @@ func (s *RepoService) ListAll(ctx context.Context) ([]*ent.Repo, error) {
 	repos := make([]*ent.Repo, 0)
 	page := 1
 
-	for true {
+	for {
 		rs, err := s.List(ctx, RepoListOptions{
 			ListOptions{
 				Page:    page,

--- a/pkg/api/repo_test.go
+++ b/pkg/api/repo_test.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"gopkg.in/h2non/gock.v1"
+
+	"github.com/AlekSi/pointer"
+	"github.com/gitploy-io/gitploy/model/ent"
+)
+
+func EqualRepo(a, b *ent.Repo) bool {
+	return a.Namespace == b.Namespace && a.Name == b.Name
+}
+
+func TestRepoService_List(t *testing.T) {
+	t.Run("Return repositories.", func(t *testing.T) {
+		repos := []*ent.Repo{
+			{
+				Namespace: "gitploy-io",
+				Name:      "gitploy",
+			},
+			{
+				Namespace: "gitploy-io",
+				Name:      "website",
+			},
+		}
+		gock.New("https://cloud.gitploy.io").
+			Get("/api/v1/repos").
+			Reply(200).
+			JSON(repos)
+
+		c := NewClient("https://cloud.gitploy.io/", http.DefaultClient)
+
+		ret, err := c.Repo.List(context.Background(), RepoListOptions{
+			ListOptions: ListOptions{Page: 1, PerPage: 30},
+		})
+		if err != nil {
+			t.Fatalf("List returns an error: %s", err)
+		}
+
+		for idx := range ret {
+			if !EqualRepo(repos[idx], ret[idx]) {
+				t.Fatalf("List = %v, wanted %v", ret, repos)
+			}
+		}
+	})
+}
+
+func TestRepoService_Get(t *testing.T) {
+	t.Run("Return the repository.", func(t *testing.T) {
+		repo := &ent.Repo{
+			Namespace: "gitploy-io",
+			Name:      "gitploy",
+		}
+		gock.New("https://cloud.gitploy.io").
+			Get("/api/v1/repos/gitploy-io/gitploy").
+			Reply(200).
+			JSON(repo)
+
+		c := NewClient("https://cloud.gitploy.io/", http.DefaultClient)
+
+		ret, err := c.Repo.Get(context.Background(), "gitploy-io", "gitploy")
+		if err != nil {
+			t.Fatalf("Get returns an error: %s", err)
+		}
+
+		if !EqualRepo(repo, ret) {
+			t.Fatalf("Get = %v, wanted %v", ret, repo)
+		}
+	})
+}
+
+func TestRepoService_Update(t *testing.T) {
+	t.Run("Update the 'config_path' field.", func(t *testing.T) {
+		gock.New("https://cloud.gitploy.io").
+			Patch("/api/v1/repos/gitploy-io/gitploy").
+			AddMatcher(func(req *http.Request, ereq *gock.Request) (bool, error) {
+				defer req.Body.Close()
+				output, _ := ioutil.ReadAll(req.Body)
+
+				b := RepoUpdateRequest{}
+				if err := json.Unmarshal(output, &b); err != nil {
+					return false, err
+				}
+
+				// Verify the field "config_path" in the body.
+				return *b.ConfigPath == "new_deploy.yml", nil
+			}).
+			Reply(200).
+			JSON(&ent.Repo{
+				Namespace:  "gitploy-io",
+				Name:       "gitploy",
+				ConfigPath: "new_deploy.yml",
+			})
+
+		c := NewClient("https://cloud.gitploy.io/", http.DefaultClient)
+
+		_, err := c.Repo.Update(context.Background(), "gitploy-io", "gitploy", RepoUpdateRequest{
+			ConfigPath: pointer.ToString("new_deploy.yml"),
+		})
+		if err != nil {
+			t.Fatalf("Update returns an error: %s", err)
+		}
+	})
+}

--- a/pkg/api/shared.go
+++ b/pkg/api/shared.go
@@ -1,0 +1,8 @@
+package api
+
+type (
+	ListOptions struct {
+		Page    int
+		PerPage int
+	}
+)


### PR DESCRIPTION
## List

<details>
<summary>gitploy repo ls</summary>

```
NAME:
   gitploy repo list - Show own repositories.

USAGE:
   gitploy repo list [command options] [arguments...]

OPTIONS:
   --all             Show all repositories. (default: false)
   --page value      The page of list. (default: 1)
   --per-page value  The item count per page. (default: 30)
   --help, -h        show help (default: false)
```

</details>

## Get

<details>
<summary>gitploy repo get</summary>

```
NAME:
   gitploy repo get - Show the repository.

USAGE:
   gitploy repo get [command options] <owner>/<repo>

OPTIONS:
   --help, -h  show help (default: false)
```

</details>

## Update

<details>
<summary>gitploy repo update</summary>

```
NAME:
   gitploy repo update - Update the repository.

USAGE:
   gitploy repo update [command options] <owner>/<repo>

OPTIONS:
   --config value, -C value  The path of the configuration file.
   --active value, -A value  Activate or deactivate the repository. Ex 'true', 'false'
   --help, -h                show help (default: false)

```

</details>


