### PR TITLE
Add the 'deployment' command into CLI

### DIFF
--- a/cmd/cli/deployment.go
+++ b/cmd/cli/deployment.go
@@ -1,0 +1,12 @@
+package main
+
+import "github.com/urfave/cli/v2"
+
+var deploymentCommand = &cli.Command{
+	Name:    "deployment",
+	Aliases: []string{"d"},
+	Usage:   "Manage deployments.",
+	Subcommands: []*cli.Command{
+		deploymentListCommand,
+	},
+}

--- a/cmd/cli/deployment.go
+++ b/cmd/cli/deployment.go
@@ -9,5 +9,7 @@ var deploymentCommand = &cli.Command{
 	Subcommands: []*cli.Command{
 		deploymentListCommand,
 		deploymentGetCommand,
+		deploymentDeployCommand,
+		deploymentUpdateCommand,
 	},
 }

--- a/cmd/cli/deployment.go
+++ b/cmd/cli/deployment.go
@@ -8,5 +8,6 @@ var deploymentCommand = &cli.Command{
 	Usage:   "Manage deployments.",
 	Subcommands: []*cli.Command{
 		deploymentListCommand,
+		deploymentGetCommand,
 	},
 }

--- a/cmd/cli/deployment_deploy.go
+++ b/cmd/cli/deployment_deploy.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"github.com/urfave/cli/v2"
+
+	"github.com/gitploy-io/gitploy/pkg/api"
+)
+
+var deploymentDeployCommand = &cli.Command{
+	Name:      "deploy",
+	Usage:     "Deploy a specific ref(branch, SHA, tag) to the environment.",
+	ArgsUsage: "<owner>/<repo>",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:     "type",
+			Usage:    "The type of the ref: 'commit', 'branch', or 'tag'.",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     "env",
+			Usage:    "The name of the environment.",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     "ref",
+			Usage:    "The specific ref. It can be any any named branch, tag, or SHA.",
+			Required: true,
+		},
+	},
+	Action: func(cli *cli.Context) error {
+		ns, n, err := splitFullName(cli.Args().First())
+		if err != nil {
+			return err
+		}
+
+		c := buildClient(cli)
+		d, err := c.Deployment.Create(cli.Context, ns, n, api.DeploymentCreateRequest{
+			Type: cli.String("type"),
+			Ref:  cli.String("ref"),
+			Env:  cli.String("env"),
+		})
+		if err != nil {
+			return err
+		}
+
+		return printJson(d, cli.String("query"))
+	},
+}

--- a/cmd/cli/deployment_get.go
+++ b/cmd/cli/deployment_get.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"strconv"
+
+	"github.com/urfave/cli/v2"
+)
+
+var deploymentGetCommand = &cli.Command{
+	Name:      "get",
+	Usage:     "Show the deployment",
+	ArgsUsage: "<owner>/<repo> <number>",
+	Action: func(cli *cli.Context) error {
+		// Validate arguments.
+		ns, n, err := splitFullName(cli.Args().First())
+		if err != nil {
+			return err
+		}
+
+		number, err := strconv.Atoi(cli.Args().Get(1))
+		if err != nil {
+			return err
+		}
+
+		c := buildClient(cli)
+		d, err := c.Deployment.Get(cli.Context, ns, n, number)
+		if err != nil {
+			return err
+		}
+
+		return printJson(d, cli.String("query"))
+	},
+}

--- a/cmd/cli/deployment_list.go
+++ b/cmd/cli/deployment_list.go
@@ -1,10 +1,6 @@
 package main
 
 import (
-	"encoding/json"
-	"fmt"
-
-	"github.com/tidwall/gjson"
 	"github.com/urfave/cli/v2"
 
 	"github.com/gitploy-io/gitploy/model/ent/deployment"
@@ -53,17 +49,6 @@ var deploymentListCommand = &cli.Command{
 			return err
 		}
 
-		output, err := json.MarshalIndent(ds, "", "  ")
-		if err != nil {
-			return fmt.Errorf("Failed to marshal: %w", err)
-		}
-
-		if q := cli.String("query"); q != "" {
-			fmt.Println(gjson.GetBytes(output, q))
-			return nil
-		}
-
-		fmt.Println(string(output))
-		return nil
+		return printJson(ds, cli.String("query"))
 	},
 }

--- a/cmd/cli/deployment_list.go
+++ b/cmd/cli/deployment_list.go
@@ -29,7 +29,7 @@ var deploymentListCommand = &cli.Command{
 		},
 		&cli.StringFlag{
 			Name:  "status",
-			Usage: "The deployment status: 'waiting', 'created', 'queued', 'running', 'success', and 'failure'. It only shows deployments the status is matched. ",
+			Usage: "The deployment status: 'waiting', 'created', 'queued', 'running', 'success', or 'failure'. It only shows deployments the status is matched. ",
 		},
 	},
 	Action: func(cli *cli.Context) error {

--- a/cmd/cli/deployment_list.go
+++ b/cmd/cli/deployment_list.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/tidwall/gjson"
+	"github.com/urfave/cli/v2"
+
+	"github.com/gitploy-io/gitploy/model/ent/deployment"
+	"github.com/gitploy-io/gitploy/pkg/api"
+)
+
+var deploymentListCommand = &cli.Command{
+	Name:      "list",
+	Aliases:   []string{"ls"},
+	Usage:     "Show the deployments under the repository.",
+	ArgsUsage: "<owner>/<repo>",
+	Flags: []cli.Flag{
+		&cli.IntFlag{
+			Name:  "page",
+			Value: 1,
+			Usage: "The page of list.",
+		},
+		&cli.IntFlag{
+			Name:  "per-page",
+			Value: 30,
+			Usage: "The item count per page.",
+		},
+		&cli.StringFlag{
+			Name:  "env",
+			Usage: "The name of environment. It only shows deployments for the environment.",
+		},
+		&cli.StringFlag{
+			Name:  "status",
+			Usage: "The deployment status: 'waiting', 'created', 'queued', 'running', 'success', and 'failure'. It only shows deployments the status is matched. ",
+		},
+	},
+	Action: func(cli *cli.Context) error {
+		c := buildClient(cli)
+
+		ns, n, err := splitFullName(cli.Args().First())
+		if err != nil {
+			return err
+		}
+
+		ds, err := c.Deployment.List(cli.Context, ns, n, api.DeploymentListOptions{
+			ListOptions: api.ListOptions{Page: cli.Int("page"), PerPage: cli.Int("per-page")},
+			Env:         cli.String("env"),
+			Status:      deployment.Status(cli.String("status")),
+		})
+		if err != nil {
+			return err
+		}
+
+		output, err := json.MarshalIndent(ds, "", "  ")
+		if err != nil {
+			return fmt.Errorf("Failed to marshal: %w", err)
+		}
+
+		if q := cli.String("query"); q != "" {
+			fmt.Println(gjson.GetBytes(output, q))
+			return nil
+		}
+
+		fmt.Println(string(output))
+		return nil
+	},
+}

--- a/cmd/cli/deployment_update.go
+++ b/cmd/cli/deployment_update.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"strconv"
+
+	"github.com/urfave/cli/v2"
+)
+
+var deploymentUpdateCommand = &cli.Command{
+	Name:      "update",
+	Usage:     "Trigger the deployment which has approved by reviews.",
+	ArgsUsage: "<owner>/<repo> <number>",
+	Action: func(cli *cli.Context) error {
+		ns, n, err := splitFullName(cli.Args().First())
+		if err != nil {
+			return err
+		}
+
+		number, err := strconv.Atoi(cli.Args().Get(1))
+		if err != nil {
+			return err
+		}
+
+		c := buildClient(cli)
+		d, err := c.Deployment.Update(cli.Context, ns, n, number)
+		if err != nil {
+			return err
+		}
+
+		return printJson(d, cli.String("query"))
+	},
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -33,6 +33,7 @@ func main() {
 		},
 		Commands: []*cli.Command{
 			repoCommand,
+			deploymentCommand,
 		},
 	}
 

--- a/cmd/cli/repo.go
+++ b/cmd/cli/repo.go
@@ -6,7 +6,7 @@ import (
 
 var repoCommand *cli.Command = &cli.Command{
 	Name:  "repo",
-	Usage: "Manage repos.",
+	Usage: "Manage repositories.",
 	Subcommands: []*cli.Command{
 		repoListCommand,
 		repoGetCommand,

--- a/cmd/cli/shared.go
+++ b/cmd/cli/shared.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
+	"github.com/tidwall/gjson"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/oauth2"
 
@@ -20,6 +22,7 @@ func buildClient(cli *cli.Context) *api.Client {
 	return api.NewClient(cli.String("host"), tc)
 }
 
+// splitFullName splits the full name into namespace, and name.
 func splitFullName(name string) (string, string, error) {
 	ss := strings.Split(name, "/")
 	if len(ss) != 2 {
@@ -27,4 +30,20 @@ func splitFullName(name string) (string, string, error) {
 	}
 
 	return ss[0], ss[1], nil
+}
+
+// printJson prints the object as JSON-format.
+func printJson(v interface{}, query string) error {
+	output, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("Failed to marshal: %w", err)
+	}
+
+	if query != "" {
+		fmt.Println(gjson.GetBytes(output, query))
+		return nil
+	}
+
+	fmt.Println(string(output))
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect
 	github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
-	github.com/tidwall/gjson v1.13.0 // indirect
+	github.com/tidwall/gjson v1.14.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/ugorji/go/codec v1.2.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -448,6 +448,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tidwall/gjson v1.13.0 h1:3TFY9yxOQShrvmjdM76K+jc66zJeT6D3/VFFYCGQf7M=
 github.com/tidwall/gjson v1.13.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.14.0 h1:6aeJ0bzojgWLa82gDQHcx3S0Lr/O51I9bJ5nv6JFx5w=
+github.com/tidwall/gjson v1.14.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -20,7 +20,8 @@ type (
 		common *client
 
 		// Services used for talking to different parts of the Gitploy API.
-		Repo *RepoService
+		Repo       *RepoService
+		Deployment *DeploymentService
 	}
 
 	client struct {
@@ -54,6 +55,7 @@ func NewClient(host string, httpClient *http.Client) *Client {
 	}
 
 	c.Repo = &RepoService{client: c.common}
+	c.Deployment = &DeploymentService{client: c.common}
 
 	return c
 }

--- a/pkg/api/deployment.go
+++ b/pkg/api/deployment.go
@@ -60,3 +60,23 @@ func (s *DeploymentService) List(ctx context.Context, namespace, name string, op
 
 	return ds, nil
 }
+
+// Get returns the deployment.
+func (s *DeploymentService) Get(ctx context.Context, namespace, name string, number int) (*ent.Deployment, error) {
+	req, err := s.client.NewRequest(
+		"GET",
+		fmt.Sprintf("api/v1/repos/%s/%s/deployments/%d", namespace, name, number),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var d *ent.Deployment
+	err = s.client.Do(ctx, req, &d)
+	if err != nil {
+		return nil, err
+	}
+
+	return d, nil
+}

--- a/pkg/api/deployment.go
+++ b/pkg/api/deployment.go
@@ -19,6 +19,12 @@ type (
 		Env    string
 		Status deployment.Status
 	}
+
+	DeploymentCreateRequest struct {
+		Type string `json:"type"`
+		Ref  string `json:"ref"`
+		Env  string `json:"env"`
+	}
 )
 
 // List returns the deployment list.
@@ -65,6 +71,46 @@ func (s *DeploymentService) List(ctx context.Context, namespace, name string, op
 func (s *DeploymentService) Get(ctx context.Context, namespace, name string, number int) (*ent.Deployment, error) {
 	req, err := s.client.NewRequest(
 		"GET",
+		fmt.Sprintf("api/v1/repos/%s/%s/deployments/%d", namespace, name, number),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var d *ent.Deployment
+	err = s.client.Do(ctx, req, &d)
+	if err != nil {
+		return nil, err
+	}
+
+	return d, nil
+}
+
+// Create requests a server to deploy a specific ref(branch, SHA, tag).
+func (s *DeploymentService) Create(ctx context.Context, namespace, name string, body DeploymentCreateRequest) (*ent.Deployment, error) {
+	req, err := s.client.NewRequest(
+		"POST",
+		fmt.Sprintf("api/v1/repos/%s/%s/deployments", namespace, name),
+		body,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var d *ent.Deployment
+	err = s.client.Do(ctx, req, &d)
+	if err != nil {
+		return nil, err
+	}
+
+	return d, nil
+}
+
+// Update requests to trigger the 'waiting' deployment.
+func (s *DeploymentService) Update(ctx context.Context, namespace, name string, number int) (*ent.Deployment, error) {
+	req, err := s.client.NewRequest(
+		"PUT",
 		fmt.Sprintf("api/v1/repos/%s/%s/deployments/%d", namespace, name, number),
 		nil,
 	)

--- a/pkg/api/deployment.go
+++ b/pkg/api/deployment.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/gitploy-io/gitploy/model/ent"
+	"github.com/gitploy-io/gitploy/model/ent/deployment"
+)
+
+type (
+	DeploymentService service
+
+	DeploymentListOptions struct {
+		ListOptions
+
+		Env    string
+		Status deployment.Status
+	}
+)
+
+// List returns the deployment list.
+// It returns an error for a bad request.
+func (s *DeploymentService) List(ctx context.Context, namespace, name string, options DeploymentListOptions) ([]*ent.Deployment, error) {
+	// Build the query.
+	vals := url.Values{}
+
+	vals.Add("page", strconv.Itoa(options.ListOptions.Page))
+	vals.Add("per_page", strconv.Itoa(options.PerPage))
+
+	if options.Env != "" {
+		vals.Add("env", options.Env)
+	}
+
+	if options.Status != "" {
+		if err := deployment.StatusValidator(options.Status); err != nil {
+			return nil, err
+		}
+
+		vals.Add("status", string(options.Status))
+	}
+
+	// Request a server.
+	req, err := s.client.NewRequest(
+		"GET",
+		fmt.Sprintf("api/v1/repos/%s/%s/deployments?%s", namespace, name, vals.Encode()),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var ds []*ent.Deployment
+	err = s.client.Do(ctx, req, &ds)
+	if err != nil {
+		return nil, err
+	}
+
+	return ds, nil
+}

--- a/pkg/api/deployment_test.go
+++ b/pkg/api/deployment_test.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/gitploy-io/gitploy/model/ent"
+	"github.com/gitploy-io/gitploy/model/ent/deployment"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestDeploymentService_List(t *testing.T) {
+	t.Run("Verify the query of a request.", func(t *testing.T) {
+		ds := []*ent.Deployment{
+			{ID: 1, Env: "production", Status: deployment.StatusWaiting},
+			{ID: 2, Env: "production", Status: deployment.StatusWaiting},
+		}
+		gock.New("https://cloud.gitploy.io").
+			Get("/api/v1/repos/gitploy-io/gitploy/deployments").
+			MatchParam("env", "production").
+			MatchParam("status", "waiting").
+			Reply(200).
+			JSON(ds)
+
+		c := NewClient("https://cloud.gitploy.io/", http.DefaultClient)
+
+		ret, err := c.Deployment.List(context.Background(), "gitploy-io", "gitploy", DeploymentListOptions{
+			ListOptions: ListOptions{Page: 1, PerPage: 30},
+			Env:         "production",
+			Status:      "waiting",
+		})
+		if err != nil {
+			t.Fatalf("List returns an error: %s", err)
+		}
+
+		for idx := range ret {
+			if ret[idx].ID != ds[idx].ID {
+				t.Fatalf("List = %v, wanted %v", ret, ds)
+			}
+		}
+	})
+}
+
+func TestDeploymentService_Create(t *testing.T) {
+	t.Run("Verify the body of a request.", func(t *testing.T) {
+		d := &ent.Deployment{
+			ID: 2, Number: 1, Type: deployment.TypeBranch, Env: "production", Ref: "main",
+		}
+		gock.New("https://cloud.gitploy.io").
+			Post("/api/v1/repos/gitploy-io/gitploy/deployments").
+			AddMatcher(func(req *http.Request, ereq *gock.Request) (bool, error) {
+				defer req.Body.Close()
+				output, _ := ioutil.ReadAll(req.Body)
+
+				b := DeploymentCreateRequest{}
+				if err := json.Unmarshal(output, &b); err != nil {
+					return false, err
+				}
+
+				// Verify the fields of the body.
+				return b.Type == "branch" && b.Env == "production" && b.Ref == "main", nil
+			}).
+			Reply(201).
+			JSON(d)
+
+		c := NewClient("https://cloud.gitploy.io/", http.DefaultClient)
+
+		_, err := c.Deployment.Create(context.Background(), "gitploy-io", "gitploy", DeploymentCreateRequest{
+			Type: "branch",
+			Env:  "production",
+			Ref:  "main",
+		})
+		if err != nil {
+			t.Fatalf("Create returns an error: %s", err)
+		}
+	})
+}
+
+func TestDeploymentService_Update(t *testing.T) {
+	t.Run("Verify the request.", func(t *testing.T) {
+		d := &ent.Deployment{
+			ID: 2, Number: 1, Type: deployment.TypeBranch, Env: "production", Ref: "main",
+		}
+		gock.New("https://cloud.gitploy.io").
+			Put("/api/v1/repos/gitploy-io/gitploy/deployments/1").
+			Reply(201).
+			JSON(d)
+
+		c := NewClient("https://cloud.gitploy.io/", http.DefaultClient)
+
+		_, err := c.Deployment.Update(context.Background(), "gitploy-io", "gitploy", 1)
+		if err != nil {
+			t.Fatalf("Create returns an error: %s", err)
+		}
+	})
+}

--- a/pkg/api/repo.go
+++ b/pkg/api/repo.go
@@ -3,6 +3,8 @@ package api
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strconv"
 
 	"github.com/gitploy-io/gitploy/model/ent"
 )
@@ -54,9 +56,14 @@ func (s *RepoService) ListAll(ctx context.Context) ([]*ent.Repo, error) {
 
 // List returns repositories which are on the page.
 func (s *RepoService) List(ctx context.Context, options RepoListOptions) ([]*ent.Repo, error) {
+	// Build the query.
+	vals := url.Values{}
+	vals.Add("page", strconv.Itoa(options.Page))
+	vals.Add("per_page", strconv.Itoa(options.PerPage))
+
 	req, err := s.client.NewRequest(
 		"GET",
-		fmt.Sprintf("api/v1/repos?page=%d&per_page=%d", options.Page, options.PerPage),
+		fmt.Sprintf("api/v1/repos?%s", vals.Encode()),
 		nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## List

<details>
<summary>deployment list</summary>

```
NAME:
   gitploy deployment list - Show the deployments under the repository.

USAGE:
   gitploy deployment list [command options] <owner>/<repo>

OPTIONS:
   --page value      The page of list. (default: 1)
   --per-page value  The item count per page. (default: 30)
   --env value       The name of the environment. It only shows deployments for the environment.
   --status value    The deployment status: 'waiting', 'created', 'queued', 'running', 'success', or 'failure'. It only shows deployments the status is matched.
   --help, -h        show help (default: false)
```

</details>

## Get

<details>
<summary>deployment get</summary>

```
NAME:
   gitploy deployment get - Show the deployment

USAGE:
   gitploy deployment get [command options] <owner>/<repo> <number>

OPTIONS:
   --help, -h  show help (default: false)
```

</details>

## Deploy

<details>
<summary>deployment deploy</summary>

```
NAME:
   gitploy deployment deploy - Deploy a specific ref(branch, SHA, tag) to the environment.

USAGE:
   gitploy deployment deploy [command options] <owner>/<repo>

OPTIONS:
   --type value  The type of the ref: 'commit', 'branch', or 'tag'.
   --env value   The name of the environment.
   --ref value   The specific ref. It can be any named branch, tag, or SHA.
   --help, -h    show help (default: false)
```
</details>

## Update

<details>
<summary>deployment update </summary>

```
NAME:
   gitploy deployment update - Trigger the deployment which has approved by reviews.

USAGE:
   gitploy deployment update [command options] <owner>/<repo> <number>

OPTIONS:
   --help, -h  show help (default: false)
```
</details>