### PR TITLE
Add the version flag to CLI

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -7,10 +7,13 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+var Version = "latest"
+
 func main() {
 	app := &cli.App{
-		Name:  "gitploy",
-		Usage: "Command line utility.",
+		Name:    "gitploy",
+		Usage:   "Command line utility.",
+		Version: Version,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:     "host",


### PR DESCRIPTION
We should build with `-ldflags` flag to link with the tag like below: 

```shell
go build -ldflags "-X main.Version=v0.6.0" ./cmd/cli
```