### PR TITLE
Add the `config` command to CLI

### DIFF
--- a/cmd/cli/config.go
+++ b/cmd/cli/config.go
@@ -1,0 +1,11 @@
+package main
+
+import "github.com/urfave/cli/v2"
+
+var configCommand = &cli.Command{
+	Name:  "config",
+	Usage: "Manage config.",
+	Subcommands: []*cli.Command{
+		configGetCommand,
+	},
+}

--- a/cmd/cli/config_get.go
+++ b/cmd/cli/config_get.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"github.com/urfave/cli/v2"
+)
+
+var configGetCommand = &cli.Command{
+	Name:      "get",
+	Usage:     "Show the pipeline configurations.",
+	ArgsUsage: "<owner>/<repo>",
+	Action: func(cli *cli.Context) error {
+		ns, n, err := splitFullName(cli.Args().First())
+		if err != nil {
+			return err
+		}
+
+		c := buildClient(cli)
+		config, err := c.Config.Get(cli.Context, ns, n)
+		if err != nil {
+			return err
+		}
+
+		return printJson(cli, config)
+	},
+}

--- a/cmd/cli/deployment_deploy.go
+++ b/cmd/cli/deployment_deploy.go
@@ -43,6 +43,6 @@ var deploymentDeployCommand = &cli.Command{
 			return err
 		}
 
-		return printJson(d, cli.String("query"))
+		return printJson(cli, d)
 	},
 }

--- a/cmd/cli/deployment_get.go
+++ b/cmd/cli/deployment_get.go
@@ -28,6 +28,6 @@ var deploymentGetCommand = &cli.Command{
 			return err
 		}
 
-		return printJson(d, cli.String("query"))
+		return printJson(cli, d)
 	},
 }

--- a/cmd/cli/deployment_list.go
+++ b/cmd/cli/deployment_list.go
@@ -49,6 +49,6 @@ var deploymentListCommand = &cli.Command{
 			return err
 		}
 
-		return printJson(ds, cli.String("query"))
+		return printJson(cli, ds)
 	},
 }

--- a/cmd/cli/deployment_update.go
+++ b/cmd/cli/deployment_update.go
@@ -27,6 +27,6 @@ var deploymentUpdateCommand = &cli.Command{
 			return err
 		}
 
-		return printJson(d, cli.String("query"))
+		return printJson(cli, d)
 	},
 }

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -37,6 +37,7 @@ func main() {
 		Commands: []*cli.Command{
 			repoCommand,
 			deploymentCommand,
+			configCommand,
 		},
 	}
 

--- a/cmd/cli/shared.go
+++ b/cmd/cli/shared.go
@@ -33,13 +33,13 @@ func splitFullName(name string) (string, string, error) {
 }
 
 // printJson prints the object as JSON-format.
-func printJson(v interface{}, query string) error {
+func printJson(cli *cli.Context, v interface{}) error {
 	output, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
 		return fmt.Errorf("Failed to marshal: %w", err)
 	}
 
-	if query != "" {
+	if query := cli.String("query"); query != "" {
 		fmt.Println(gjson.GetBytes(output, query))
 		return nil
 	}

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -22,6 +22,7 @@ type (
 		// Services used for talking to different parts of the Gitploy API.
 		Repo       *RepoService
 		Deployment *DeploymentService
+		Config     *ConfigService
 	}
 
 	client struct {
@@ -56,6 +57,7 @@ func NewClient(host string, httpClient *http.Client) *Client {
 
 	c.Repo = &RepoService{client: c.common}
 	c.Deployment = &DeploymentService{client: c.common}
+	c.Config = &ConfigService{client: c.common}
 
 	return c
 }

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gitploy-io/gitploy/model/extent"
+)
+
+type (
+	ConfigService service
+)
+
+func (s *ConfigService) Get(ctx context.Context, namespace, name string) (*extent.Config, error) {
+	req, err := s.client.NewRequest(
+		"GET",
+		fmt.Sprintf("api/v1/repos/%s/%s/config", namespace, name),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var config *extent.Config
+	if err := s.client.Do(ctx, req, &config); err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -19,7 +19,7 @@ func TestConfig_Get(t *testing.T) {
 		}
 
 		gock.New("https://cloud.gitploy.io").
-			Get("/api/v1/gitploy-io/gitploy/config").
+			Get("/api/v1/repos/gitploy-io/gitploy/config").
 			Reply(200).
 			JSON(config)
 

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/gitploy-io/gitploy/model/extent"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestConfig_Get(t *testing.T) {
+	t.Run("Return the config.", func(t *testing.T) {
+		config := &extent.Config{
+			Envs: []*extent.Env{
+				{Name: "production"},
+			},
+		}
+
+		gock.New("https://cloud.gitploy.io").
+			Get("/api/v1/gitploy-io/gitploy/config").
+			Reply(200).
+			JSON(config)
+
+		c := NewClient("https://cloud.gitploy.io/", http.DefaultClient)
+
+		ret, err := c.Config.Get(context.Background(), "gitploy-io", "gitploy")
+		if err != nil {
+			t.Fatalf("Get returns an error: %s", err)
+		}
+
+		if !reflect.DeepEqual(ret, config) {
+			t.Fatalf("Get = %v, wanted %v", ret, config)
+		}
+	})
+}


### PR DESCRIPTION
## Get

```
NAME:
   gitploy config get - Show the pipeline configurations.

USAGE:
   gitploy config get [command options] <owner>/<repo>

OPTIONS:
   --help, -h  show help (default: false)
```