### PR TITLE
Remove `CreateEvent` from the repo API

### DIFF
--- a/internal/interactor/interactor.go
+++ b/internal/interactor/interactor.go
@@ -25,6 +25,7 @@ type (
 		*LicenseInteractor
 		*LockInteractor
 		*RepoInteractor
+		*ReviewInteractor
 		*UserInteractor
 	}
 
@@ -86,6 +87,7 @@ func NewInteractor(c *InteractorConfig) *Interactor {
 		WebhookSSL:    c.ServerProxyProto == "https",
 		WebhookSecret: c.WebhookSecret,
 	}
+	i.ReviewInteractor = (*ReviewInteractor)(i.common)
 	i.UserInteractor = &UserInteractor{
 		service:       i.common,
 		admins:        c.AdminUsers,

--- a/internal/interactor/interface.go
+++ b/internal/interactor/interface.go
@@ -47,16 +47,6 @@ type (
 		SyncDeploymentStatus(ctx context.Context, ds *ent.DeploymentStatus) (*ent.DeploymentStatus, error)
 	}
 
-	// ReviewStore defines operations for working with reviews.
-	ReviewStore interface {
-		SearchReviews(ctx context.Context, u *ent.User) ([]*ent.Review, error)
-		ListReviews(ctx context.Context, d *ent.Deployment) ([]*ent.Review, error)
-		FindReviewOfUser(ctx context.Context, u *ent.User, d *ent.Deployment) (*ent.Review, error)
-		FindReviewByID(ctx context.Context, id int) (*ent.Review, error)
-		CreateReview(ctx context.Context, rv *ent.Review) (*ent.Review, error)
-		UpdateReview(ctx context.Context, rv *ent.Review) (*ent.Review, error)
-	}
-
 	SCM interface {
 		UserSCM
 		RepoSCM

--- a/internal/interactor/review.go
+++ b/internal/interactor/review.go
@@ -1,0 +1,44 @@
+package interactor
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/gitploy-io/gitploy/model/ent"
+	"github.com/gitploy-io/gitploy/model/ent/event"
+)
+
+type (
+	ReviewInteractor service
+
+	// ReviewStore defines operations for working with reviews.
+	ReviewStore interface {
+		SearchReviews(ctx context.Context, u *ent.User) ([]*ent.Review, error)
+		ListReviews(ctx context.Context, d *ent.Deployment) ([]*ent.Review, error)
+		FindReviewOfUser(ctx context.Context, u *ent.User, d *ent.Deployment) (*ent.Review, error)
+		FindReviewByID(ctx context.Context, id int) (*ent.Review, error)
+		// CreateReview creates a review of which status is pending.
+		CreateReview(ctx context.Context, rv *ent.Review) (*ent.Review, error)
+		// UpdateReview update the status and comment of the review.
+		UpdateReview(ctx context.Context, rv *ent.Review) (*ent.Review, error)
+	}
+)
+
+// RespondReview update the status of review.
+func (i *ReviewInteractor) RespondReview(ctx context.Context, rv *ent.Review) (*ent.Review, error) {
+	rv, err := i.store.UpdateReview(ctx, rv)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := i.store.CreateEvent(ctx, &ent.Event{
+		Kind:     event.KindReview,
+		Type:     event.TypeCreated,
+		ReviewID: rv.ID,
+	}); err != nil {
+		i.log.Error("Failed to create a review event.", zap.Error(err))
+	}
+
+	return rv, nil
+}

--- a/internal/interactor/review_test.go
+++ b/internal/interactor/review_test.go
@@ -1,0 +1,38 @@
+package interactor_test
+
+import (
+	"context"
+	"testing"
+
+	gm "github.com/golang/mock/gomock"
+
+	i "github.com/gitploy-io/gitploy/internal/interactor"
+	"github.com/gitploy-io/gitploy/internal/interactor/mock"
+	"github.com/gitploy-io/gitploy/model/ent"
+)
+
+func TestInteractor_RespondReview(t *testing.T) {
+	t.Run("Return the review.", func(t *testing.T) {
+		t.Log("Start mocking:")
+		ctrl := gm.NewController(t)
+		store := mock.NewMockStore(ctrl)
+
+		t.Log("\tUpdates the review and dispatches a event.")
+		store.EXPECT().
+			UpdateReview(gm.Any(), gm.AssignableToTypeOf(&ent.Review{})).
+			Return(&ent.Review{}, nil)
+
+		store.EXPECT().
+			CreateEvent(gm.Any(), gm.AssignableToTypeOf(&ent.Event{})).
+			Return(&ent.Event{}, nil)
+
+		it := i.NewInteractor(&i.InteractorConfig{
+			Store: store,
+		})
+		_, err := it.RespondReview(context.Background(), &ent.Review{})
+		if err != nil {
+			t.Fatalf("RespondReview returns an error: %v", err)
+		}
+	})
+
+}

--- a/internal/server/api/v1/repos/interface.go
+++ b/internal/server/api/v1/repos/interface.go
@@ -39,6 +39,7 @@ type (
 		ListReviews(ctx context.Context, d *ent.Deployment) ([]*ent.Review, error)
 		FindReviewOfUser(ctx context.Context, u *ent.User, d *ent.Deployment) (*ent.Review, error)
 		UpdateReview(ctx context.Context, rv *ent.Review) (*ent.Review, error)
+		RespondReview(ctx context.Context, rv *ent.Review) (*ent.Review, error)
 
 		ListLocksOfRepo(ctx context.Context, r *ent.Repo) ([]*ent.Lock, error)
 		HasLockOfRepoForEnv(ctx context.Context, r *ent.Repo, env string) (bool, error)

--- a/internal/server/api/v1/repos/mock/interactor.go
+++ b/internal/server/api/v1/repos/mock/interactor.go
@@ -547,6 +547,21 @@ func (mr *MockInteractorMockRecorder) ListTags(ctx, u, r, opt interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTags", reflect.TypeOf((*MockInteractor)(nil).ListTags), ctx, u, r, opt)
 }
 
+// RespondReview mocks base method.
+func (m *MockInteractor) RespondReview(ctx context.Context, rv *ent.Review) (*ent.Review, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RespondReview", ctx, rv)
+	ret0, _ := ret[0].(*ent.Review)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RespondReview indicates an expected call of RespondReview.
+func (mr *MockInteractorMockRecorder) RespondReview(ctx, rv interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RespondReview", reflect.TypeOf((*MockInteractor)(nil).RespondReview), ctx, rv)
+}
+
 // UpdateLock mocks base method.
 func (m *MockInteractor) UpdateLock(ctx context.Context, l *ent.Lock) (*ent.Lock, error) {
 	m.ctrl.T.Helper()

--- a/internal/server/api/v1/repos/review_update.go
+++ b/internal/server/api/v1/repos/review_update.go
@@ -16,7 +16,6 @@ import (
 
 	gb "github.com/gitploy-io/gitploy/internal/server/global"
 	"github.com/gitploy-io/gitploy/model/ent"
-	"github.com/gitploy-io/gitploy/model/ent/event"
 	"github.com/gitploy-io/gitploy/model/ent/review"
 	"github.com/gitploy-io/gitploy/pkg/e"
 )
@@ -80,19 +79,12 @@ func (s *ReviewAPI) UpdateMine(c *gin.Context) {
 		rv.Comment = *p.Comment
 	}
 
-	if rv, err = s.i.UpdateReview(ctx, rv); err != nil {
+	if rv, err = s.i.RespondReview(ctx, rv); err != nil {
 		s.log.Check(gb.GetZapLogLevel(err), "Failed to update the review.").Write(zap.Error(err))
 		gb.ResponseWithError(c, err)
 		return
 	}
 
-	if _, err := s.i.CreateEvent(ctx, &ent.Event{
-		Kind:     event.KindReview,
-		Type:     event.TypeUpdated,
-		ReviewID: rv.ID,
-	}); err != nil {
-		s.log.Error("Failed to create the event.", zap.Error(err))
-	}
-
+	s.log.Info("Respond the review successfully.", zap.Int("review_id", rv.ID))
 	gb.Response(c, http.StatusOK, rv)
 }


### PR DESCRIPTION
We have been working on hiding the application logic as an interactor. As part of this, I have removed the `CreateEvent` method from the review API.