### PR TITLE
Add the `deployment-status` command 

### DIFF
--- a/cmd/cli/deployment_deploy.go
+++ b/cmd/cli/deployment_deploy.go
@@ -34,7 +34,7 @@ var deploymentDeployCommand = &cli.Command{
 		}
 
 		c := buildClient(cli)
-		d, err := c.Deployment.Create(cli.Context, ns, n, api.DeploymentCreateRequest{
+		d, err := c.Deployment.Create(cli.Context, ns, n, &api.DeploymentCreateRequest{
 			Type: cli.String("type"),
 			Ref:  cli.String("ref"),
 			Env:  cli.String("env"),

--- a/cmd/cli/deployment_list.go
+++ b/cmd/cli/deployment_list.go
@@ -40,7 +40,7 @@ var deploymentListCommand = &cli.Command{
 			return err
 		}
 
-		ds, err := c.Deployment.List(cli.Context, ns, n, api.DeploymentListOptions{
+		ds, err := c.Deployment.List(cli.Context, ns, n, &api.DeploymentListOptions{
 			ListOptions: api.ListOptions{Page: cli.Int("page"), PerPage: cli.Int("per-page")},
 			Env:         cli.String("env"),
 			Status:      deployment.Status(cli.String("status")),

--- a/cmd/cli/deploymentstatus.go
+++ b/cmd/cli/deploymentstatus.go
@@ -1,0 +1,13 @@
+package main
+
+import "github.com/urfave/cli/v2"
+
+var deploymentStatusCommand = &cli.Command{
+	Name:    "deployment-status",
+	Aliases: []string{"ds"},
+	Usage:   "Manage deployment statuses.",
+	Subcommands: []*cli.Command{
+		deploymentStatusListCommand,
+		deploymentStatusCreateCommand,
+	},
+}

--- a/cmd/cli/deploymentstatus_create.go
+++ b/cmd/cli/deploymentstatus_create.go
@@ -21,7 +21,7 @@ var deploymentStatusCreateCommand = &cli.Command{
 		&cli.StringFlag{
 			Name:        "description",
 			Usage:       "A short description of the status.",
-			DefaultText: "Update the deployment status manually.",
+			DefaultText: "User updated the status manually.",
 		},
 	},
 	Action: func(cli *cli.Context) error {
@@ -37,7 +37,7 @@ var deploymentStatusCreateCommand = &cli.Command{
 
 		c := buildClient(cli)
 		dss, err := c.DeploymentStatus.CreateRemote(cli.Context, ns, n, number, api.DeploymentStatusCreateRemoteRequest{
-			Status:      cli.String("stattus"),
+			Status:      cli.String("status"),
 			Description: cli.String("description"),
 		})
 		if err != nil {

--- a/cmd/cli/deploymentstatus_create.go
+++ b/cmd/cli/deploymentstatus_create.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"strconv"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/gitploy-io/gitploy/pkg/api"
+)
+
+var deploymentStatusCreateCommand = &cli.Command{
+	Name:      "create",
+	Usage:     "Create the remote deployment status under the deployment.",
+	ArgsUsage: "<owner>/<repo> <number>",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:     "status",
+			Usage:    "The remote deployment status. For GitHub, Can be one of error, failure, in_progress, queued, or success.",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:        "description",
+			Usage:       "A short description of the status.",
+			DefaultText: "Update the deployment status manually.",
+		},
+	},
+	Action: func(cli *cli.Context) error {
+		ns, n, err := splitFullName(cli.Args().First())
+		if err != nil {
+			return err
+		}
+
+		number, err := strconv.Atoi(cli.Args().Get(1))
+		if err != nil {
+			return err
+		}
+
+		c := buildClient(cli)
+		dss, err := c.DeploymentStatus.CreateRemote(cli.Context, ns, n, number, api.DeploymentStatusCreateRemoteRequest{
+			Status:      cli.String("stattus"),
+			Description: cli.String("description"),
+		})
+		if err != nil {
+			return err
+		}
+
+		return printJson(cli, dss)
+	},
+}

--- a/cmd/cli/deploymentstatus_create.go
+++ b/cmd/cli/deploymentstatus_create.go
@@ -38,7 +38,7 @@ var deploymentStatusCreateCommand = &cli.Command{
 
 		// Build the request.
 		c := buildClient(cli)
-		req := api.DeploymentStatusCreateRemoteRequest{
+		req := &api.DeploymentStatusCreateRemoteRequest{
 			Status:      cli.String("status"),
 			Description: cli.String("description"),
 		}

--- a/cmd/cli/deploymentstatus_list.go
+++ b/cmd/cli/deploymentstatus_list.go
@@ -25,7 +25,7 @@ var deploymentStatusListCommand = &cli.Command{
 		}
 
 		c := buildClient(cli)
-		dss, err := c.DeploymentStatus.List(cli.Context, ns, n, number, api.ListOptions{})
+		dss, err := c.DeploymentStatus.List(cli.Context, ns, n, number, &api.ListOptions{})
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/deploymentstatus_list.go
+++ b/cmd/cli/deploymentstatus_list.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"strconv"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/gitploy-io/gitploy/pkg/api"
+)
+
+var deploymentStatusListCommand = &cli.Command{
+	Name:      "list",
+	Aliases:   []string{"ls"},
+	Usage:     "Show the deployment status under the deployment.",
+	ArgsUsage: "<owner>/<repo> <number>",
+	Action: func(cli *cli.Context) error {
+		ns, n, err := splitFullName(cli.Args().First())
+		if err != nil {
+			return err
+		}
+
+		number, err := strconv.Atoi(cli.Args().Get(1))
+		if err != nil {
+			return err
+		}
+
+		c := buildClient(cli)
+		dss, err := c.DeploymentStatus.List(cli.Context, ns, n, number, api.ListOptions{})
+		if err != nil {
+			return err
+		}
+
+		return printJson(cli, dss)
+	},
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -37,6 +37,7 @@ func main() {
 		Commands: []*cli.Command{
 			repoCommand,
 			deploymentCommand,
+			deploymentStatusCommand,
 			configCommand,
 		},
 	}

--- a/cmd/cli/repo_list.go
+++ b/cmd/cli/repo_list.go
@@ -44,7 +44,7 @@ var repoListCommand = &cli.Command{
 				return err
 			}
 		} else {
-			if repos, err = c.Repo.List(cli.Context, api.RepoListOptions{
+			if repos, err = c.Repo.List(cli.Context, &api.RepoListOptions{
 				ListOptions: api.ListOptions{Page: cli.Int("page"), PerPage: cli.Int("per-page")},
 			}); err != nil {
 				return err

--- a/cmd/cli/repo_update.go
+++ b/cmd/cli/repo_update.go
@@ -34,7 +34,7 @@ var repoUpdateCommand = &cli.Command{
 		}
 
 		// Build the request body.
-		req := api.RepoUpdateRequest{}
+		req := &api.RepoUpdateRequest{}
 		if config := cli.String("config"); config != "" {
 			req.ConfigPath = pointer.ToString(config)
 		}

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -19,11 +19,12 @@ type (
 		// Reuse a single struct instead of allocating one for each service on the heap.
 		common *client
 
-		// Services used for talking to different parts of the Gitploy API.
+		// Services is used for talking to different parts of the Gitploy API.
 		Repo             *RepoService
 		Deployment       *DeploymentService
 		DeploymentStatus *DeploymentStatusService
 		Config           *ConfigService
+		User             *UserService
 	}
 
 	client struct {
@@ -60,6 +61,7 @@ func NewClient(host string, httpClient *http.Client) *Client {
 	c.Deployment = &DeploymentService{client: c.common}
 	c.DeploymentStatus = &DeploymentStatusService{client: c.common}
 	c.Config = &ConfigService{client: c.common}
+	c.User = &UserService{client: c.common}
 
 	return c
 }

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -20,9 +20,10 @@ type (
 		common *client
 
 		// Services used for talking to different parts of the Gitploy API.
-		Repo       *RepoService
-		Deployment *DeploymentService
-		Config     *ConfigService
+		Repo             *RepoService
+		Deployment       *DeploymentService
+		DeploymentStatus *DeploymentStatusService
+		Config           *ConfigService
 	}
 
 	client struct {
@@ -57,6 +58,7 @@ func NewClient(host string, httpClient *http.Client) *Client {
 
 	c.Repo = &RepoService{client: c.common}
 	c.Deployment = &DeploymentService{client: c.common}
+	c.DeploymentStatus = &DeploymentStatusService{client: c.common}
 	c.Config = &ConfigService{client: c.common}
 
 	return c

--- a/pkg/api/deployment.go
+++ b/pkg/api/deployment.go
@@ -29,7 +29,7 @@ type (
 
 // List returns the deployment list.
 // It returns an error for a bad request.
-func (s *DeploymentService) List(ctx context.Context, namespace, name string, options DeploymentListOptions) ([]*ent.Deployment, error) {
+func (s *DeploymentService) List(ctx context.Context, namespace, name string, options *DeploymentListOptions) ([]*ent.Deployment, error) {
 	// Build the query.
 	vals := url.Values{}
 
@@ -88,7 +88,7 @@ func (s *DeploymentService) Get(ctx context.Context, namespace, name string, num
 }
 
 // Create requests a server to deploy a specific ref(branch, SHA, tag).
-func (s *DeploymentService) Create(ctx context.Context, namespace, name string, body DeploymentCreateRequest) (*ent.Deployment, error) {
+func (s *DeploymentService) Create(ctx context.Context, namespace, name string, body *DeploymentCreateRequest) (*ent.Deployment, error) {
 	req, err := s.client.NewRequest(
 		"POST",
 		fmt.Sprintf("api/v1/repos/%s/%s/deployments", namespace, name),

--- a/pkg/api/deployment_status.go
+++ b/pkg/api/deployment_status.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gitploy-io/gitploy/model/ent"
+	"github.com/gitploy-io/gitploy/model/extent"
+)
+
+type (
+	DeploymentStatusService service
+
+	DeploymentStatusCreateRemoteRequest struct {
+		Status      string `json:"status"`
+		Description string `json:"description"`
+		LogURL      string `json:"log_url"`
+	}
+)
+
+// List returns the list of deployment statuses.
+// It returns an error for a bad request.
+func (s *DeploymentStatusService) List(ctx context.Context, namespace, name string, number int, opt ListOptions) ([]*ent.DeploymentStatus, error) {
+	req, err := s.client.NewRequest(
+		"GET",
+		fmt.Sprintf("api/v1/repos/%s/%s/deployments/%d/statuses", namespace, name, number),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var dss []*ent.DeploymentStatus
+	if err := s.client.Do(ctx, req, &dss); err != nil {
+		return nil, err
+	}
+
+	return dss, nil
+}
+
+// CreateRemote returns the remote status.
+// It returns an error for a bad request.
+func (s *DeploymentStatusService) CreateRemote(ctx context.Context, namespace, name string, number int, body DeploymentStatusCreateRemoteRequest) (*extent.RemoteDeploymentStatus, error) {
+	req, err := s.client.NewRequest(
+		"POST",
+		fmt.Sprintf("api/v1/repos/%s/%s/deployments/%d/remote-statuses", namespace, name, number),
+		body,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var ds *extent.RemoteDeploymentStatus
+	if err := s.client.Do(ctx, req, &ds); err != nil {
+		return nil, err
+	}
+
+	return ds, nil
+}

--- a/pkg/api/deployment_status.go
+++ b/pkg/api/deployment_status.go
@@ -20,7 +20,7 @@ type (
 
 // List returns the list of deployment statuses.
 // It returns an error for a bad request.
-func (s *DeploymentStatusService) List(ctx context.Context, namespace, name string, number int, opt ListOptions) ([]*ent.DeploymentStatus, error) {
+func (s *DeploymentStatusService) List(ctx context.Context, namespace, name string, number int, opt *ListOptions) ([]*ent.DeploymentStatus, error) {
 	req, err := s.client.NewRequest(
 		"GET",
 		fmt.Sprintf("api/v1/repos/%s/%s/deployments/%d/statuses", namespace, name, number),
@@ -40,7 +40,7 @@ func (s *DeploymentStatusService) List(ctx context.Context, namespace, name stri
 
 // CreateRemote returns the remote status.
 // It returns an error for a bad request.
-func (s *DeploymentStatusService) CreateRemote(ctx context.Context, namespace, name string, number int, body DeploymentStatusCreateRemoteRequest) (*extent.RemoteDeploymentStatus, error) {
+func (s *DeploymentStatusService) CreateRemote(ctx context.Context, namespace, name string, number int, body *DeploymentStatusCreateRemoteRequest) (*extent.RemoteDeploymentStatus, error) {
 	req, err := s.client.NewRequest(
 		"POST",
 		fmt.Sprintf("api/v1/repos/%s/%s/deployments/%d/remote-statuses", namespace, name, number),

--- a/pkg/api/deployment_status_test.go
+++ b/pkg/api/deployment_status_test.go
@@ -22,7 +22,7 @@ func TestDeploymentStatus_List(t *testing.T) {
 
 		c := NewClient("https://cloud.gitploy.io/", http.DefaultClient)
 
-		_, err := c.DeploymentStatus.List(context.Background(), "gitploy-io", "gitploy", 1, ListOptions{})
+		_, err := c.DeploymentStatus.List(context.Background(), "gitploy-io", "gitploy", 1, &ListOptions{})
 		if err != nil {
 			t.Fatalf("Create returns an error: %s", err)
 		}
@@ -38,7 +38,7 @@ func TestDeploymentStatus_Create(t *testing.T) {
 
 		c := NewClient("https://cloud.gitploy.io/", http.DefaultClient)
 
-		_, err := c.DeploymentStatus.CreateRemote(context.Background(), "gitploy-io", "gitploy", 1, DeploymentStatusCreateRemoteRequest{})
+		_, err := c.DeploymentStatus.CreateRemote(context.Background(), "gitploy-io", "gitploy", 1, &DeploymentStatusCreateRemoteRequest{})
 		if err != nil {
 			t.Fatalf("Create returns an error: %s", err)
 		}

--- a/pkg/api/deployment_status_test.go
+++ b/pkg/api/deployment_status_test.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/gitploy-io/gitploy/model/ent"
+	"github.com/gitploy-io/gitploy/model/extent"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestDeploymentStatus_List(t *testing.T) {
+	t.Run("Return the list of statuses.", func(t *testing.T) {
+		dss := []*ent.DeploymentStatus{
+			{ID: 1},
+		}
+		gock.New("https://cloud.gitploy.io").
+			Get("/api/v1/repos/gitploy-io/gitploy/deployments/1/statuses").
+			Reply(200).
+			JSON(dss)
+
+		c := NewClient("https://cloud.gitploy.io/", http.DefaultClient)
+
+		_, err := c.DeploymentStatus.List(context.Background(), "gitploy-io", "gitploy", 1, ListOptions{})
+		if err != nil {
+			t.Fatalf("Create returns an error: %s", err)
+		}
+	})
+}
+
+func TestDeploymentStatus_Create(t *testing.T) {
+	t.Run("Return the deployment statuses.", func(t *testing.T) {
+		gock.New("https://cloud.gitploy.io").
+			Post("/api/v1/repos/gitploy-io/gitploy/deployments/1/remote-statuses").
+			Reply(201).
+			JSON(extent.RemoteDeploymentStatus{ID: 1})
+
+		c := NewClient("https://cloud.gitploy.io/", http.DefaultClient)
+
+		_, err := c.DeploymentStatus.CreateRemote(context.Background(), "gitploy-io", "gitploy", 1, DeploymentStatusCreateRemoteRequest{})
+		if err != nil {
+			t.Fatalf("Create returns an error: %s", err)
+		}
+	})
+}

--- a/pkg/api/deployment_test.go
+++ b/pkg/api/deployment_test.go
@@ -27,7 +27,7 @@ func TestDeploymentService_List(t *testing.T) {
 
 		c := NewClient("https://cloud.gitploy.io/", http.DefaultClient)
 
-		ret, err := c.Deployment.List(context.Background(), "gitploy-io", "gitploy", DeploymentListOptions{
+		ret, err := c.Deployment.List(context.Background(), "gitploy-io", "gitploy", &DeploymentListOptions{
 			ListOptions: ListOptions{Page: 1, PerPage: 30},
 			Env:         "production",
 			Status:      "waiting",
@@ -68,7 +68,7 @@ func TestDeploymentService_Create(t *testing.T) {
 
 		c := NewClient("https://cloud.gitploy.io/", http.DefaultClient)
 
-		_, err := c.Deployment.Create(context.Background(), "gitploy-io", "gitploy", DeploymentCreateRequest{
+		_, err := c.Deployment.Create(context.Background(), "gitploy-io", "gitploy", &DeploymentCreateRequest{
 			Type: "branch",
 			Env:  "production",
 			Ref:  "main",

--- a/pkg/api/repo.go
+++ b/pkg/api/repo.go
@@ -31,7 +31,7 @@ func (s *RepoService) ListAll(ctx context.Context) ([]*ent.Repo, error) {
 	page := 1
 
 	for {
-		rs, err := s.List(ctx, RepoListOptions{
+		rs, err := s.List(ctx, &RepoListOptions{
 			ListOptions{
 				Page:    page,
 				PerPage: perPage,
@@ -55,7 +55,7 @@ func (s *RepoService) ListAll(ctx context.Context) ([]*ent.Repo, error) {
 }
 
 // List returns repositories which are on the page.
-func (s *RepoService) List(ctx context.Context, options RepoListOptions) ([]*ent.Repo, error) {
+func (s *RepoService) List(ctx context.Context, options *RepoListOptions) ([]*ent.Repo, error) {
 	// Build the query.
 	vals := url.Values{}
 	vals.Add("page", strconv.Itoa(options.Page))
@@ -95,7 +95,7 @@ func (s *RepoService) Get(ctx context.Context, namespace, name string) (*ent.Rep
 	return repo, nil
 }
 
-func (s *RepoService) Update(ctx context.Context, namespace, name string, options RepoUpdateRequest) (*ent.Repo, error) {
+func (s *RepoService) Update(ctx context.Context, namespace, name string, options *RepoUpdateRequest) (*ent.Repo, error) {
 	req, err := s.client.NewRequest(
 		"PATCH",
 		fmt.Sprintf("api/v1/repos/%s/%s", namespace, name),

--- a/pkg/api/repo_test.go
+++ b/pkg/api/repo_test.go
@@ -36,7 +36,7 @@ func TestRepoService_List(t *testing.T) {
 
 		c := NewClient("https://cloud.gitploy.io/", http.DefaultClient)
 
-		ret, err := c.Repo.List(context.Background(), RepoListOptions{
+		ret, err := c.Repo.List(context.Background(), &RepoListOptions{
 			ListOptions: ListOptions{Page: 1, PerPage: 30},
 		})
 		if err != nil {
@@ -100,7 +100,7 @@ func TestRepoService_Update(t *testing.T) {
 
 		c := NewClient("https://cloud.gitploy.io/", http.DefaultClient)
 
-		_, err := c.Repo.Update(context.Background(), "gitploy-io", "gitploy", RepoUpdateRequest{
+		_, err := c.Repo.Update(context.Background(), "gitploy-io", "gitploy", &RepoUpdateRequest{
 			ConfigPath: pointer.ToString("new_deploy.yml"),
 		})
 		if err != nil {

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/gitploy-io/gitploy/model/ent"
 )
@@ -16,7 +15,7 @@ type (
 func (s *UserService) GetMe(ctx context.Context) (*ent.User, error) {
 	req, err := s.client.NewRequest(
 		"GET",
-		fmt.Sprint("/api/v1/user"),
+		"/api/v1/user",
 		nil,
 	)
 	if err != nil {

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gitploy-io/gitploy/model/ent"
+)
+
+type (
+	// UserService communicates with the server for users.
+	UserService service
+)
+
+// GetMe returns the user information.
+func (s *UserService) GetMe(ctx context.Context) (*ent.User, error) {
+	req, err := s.client.NewRequest(
+		"GET",
+		fmt.Sprintf("/api/v1/user"),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var u *ent.User
+	if err := s.client.Do(ctx, req, &u); err != nil {
+		return nil, err
+	}
+
+	return u, nil
+}

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -16,7 +16,7 @@ type (
 func (s *UserService) GetMe(ctx context.Context) (*ent.User, error) {
 	req, err := s.client.NewRequest(
 		"GET",
-		fmt.Sprintf("/api/v1/user"),
+		fmt.Sprint("/api/v1/user"),
 		nil,
 	)
 	if err != nil {


### PR DESCRIPTION
I've added the `deployment-status` command to list and update deployment status:

```
NAME:
   gitploy deployment-status - Manage deployment statuses.

USAGE:
   gitploy deployment-status command [command options] [arguments...]

COMMANDS:
   list, ls  Show the deployment status under the deployment.
   create    Create the remote deployment status under the deployment.
   help, h   Shows a list of commands or help for one command

OPTIONS:
   --help, -h  show help (default: false)
```