### PR TITLE
Display the `Token` in the settings page

### DIFF
--- a/internal/server/api/v1/users/get.go
+++ b/internal/server/api/v1/users/get.go
@@ -10,6 +10,15 @@ import (
 	"github.com/gitploy-io/gitploy/model/ent"
 )
 
+type (
+	// extendedUserData includes the 'hash' field.
+	extendedUserData struct {
+		*ent.User
+
+		Hash string `json:"hash"`
+	}
+)
+
 func (u *UserAPI) GetMe(c *gin.Context) {
 	ctx := c.Request.Context()
 
@@ -23,5 +32,8 @@ func (u *UserAPI) GetMe(c *gin.Context) {
 		return
 	}
 
-	gb.Response(c, http.StatusOK, uv)
+	gb.Response(c, http.StatusOK, extendedUserData{
+		User: uv,
+		Hash: uv.Hash,
+	})
 }

--- a/internal/server/api/v1/users/get_test.go
+++ b/internal/server/api/v1/users/get_test.go
@@ -1,0 +1,59 @@
+package users
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gitploy-io/gitploy/internal/server/api/v1/users/mock"
+	"github.com/gitploy-io/gitploy/internal/server/global"
+	"github.com/gitploy-io/gitploy/model/ent"
+	gm "github.com/golang/mock/gomock"
+)
+
+func init() {
+	gin.SetMode(gin.ReleaseMode)
+}
+
+func TestUsers_GetMe(t *testing.T) {
+	t.Run("Return user's information with the 'hash' field.", func(t *testing.T) {
+		const hash = "HASH_VALUE"
+
+		t.Log("Start mocking:")
+		ctrl := gm.NewController(t)
+		i := mock.NewMockInteractor(ctrl)
+
+		t.Log("\tFind the user.")
+		i.EXPECT().
+			FindUserByID(gm.Any(), gm.AssignableToTypeOf(int64(1))).
+			Return(&ent.User{Hash: hash}, nil)
+
+		api := NewUserAPI(i)
+		r := gin.New()
+		r.GET("/user",
+			func(c *gin.Context) {
+				c.Set(global.KeyUser, &ent.User{})
+			},
+			api.GetMe)
+
+		req, _ := http.NewRequest("GET", "/user", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		t.Log("Evaluate the return value.")
+		if w.Code != http.StatusOK {
+			t.Fatalf("Code = %v, wanted %v", w.Code, http.StatusOK)
+		}
+
+		d := extendedUserData{}
+		if err := json.Unmarshal(w.Body.Bytes(), &d); err != nil {
+			t.Fatalf("Failed to unmarshal: %v", err)
+		}
+
+		if d.Hash != hash {
+			t.Fatalf("Hash = %v, wanted %v", d.Hash, hash)
+		}
+	})
+}

--- a/internal/server/api/v1/users/update_test.go
+++ b/internal/server/api/v1/users/update_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/golang/mock/gomock"
 )
 
-func TestUser_UpdateUser(t *testing.T) {
+func TestUserAPI_UpdateUser(t *testing.T) {
 	input := struct {
 		ID      int64
 		Payload *userPatchPayload

--- a/ui/src/apis/user.ts
+++ b/ui/src/apis/user.ts
@@ -9,6 +9,7 @@ export interface UserData {
     login: string
     avatar: string
     admin: boolean
+    hash?: string
     created_at: string
     updated_at: string
     edges: {
@@ -47,6 +48,7 @@ export const mapDataToUser = (data: UserData): User => {
         login: data.login,
         avatar: data.avatar,
         admin: data.admin,
+        hash: data.hash,
         createdAt: new Date(data.created_at),
         updatedAt: new Date(data.updated_at),
         chatUser: cu,

--- a/ui/src/models/User.ts
+++ b/ui/src/models/User.ts
@@ -3,6 +3,8 @@ export default interface User {
     login: string
     avatar: string
     admin: boolean
+    // It exists only when getting self user.
+    hash?: string
     createdAt: Date
     updatedAt: Date
     chatUser: ChatUser | null

--- a/ui/src/views/Settings.tsx
+++ b/ui/src/views/Settings.tsx
@@ -1,11 +1,11 @@
-import { Avatar, Button, Tag } from "antd"
-import moment from "moment"
 import { useEffect } from "react"
 import { shallowEqual } from "react-redux"
 import { Helmet } from "react-helmet"
+import { Avatar, Button, Tag, Descriptions } from "antd"
+import moment from "moment"
 
 import { useAppSelector, useAppDispatch } from "../redux/hooks"
-import { fetchMe, fetchRateLimit,checkSlack } from "../redux/settings"
+import { fetchMe, fetchRateLimit, checkSlack } from "../redux/settings"
 
 import Main from "./Main"
 
@@ -27,24 +27,23 @@ export default function Settings(): JSX.Element {
             <Helmet>
                 <title>Settings</title>
             </Helmet>
-            <div >
-                <h1>Settings</h1>
-            </div>
-            <div style={{marginTop: "40px"}}>
-                <h2>User</h2>
-                <p>
-                    Login: <Avatar src={user?.avatar}/> <b>{user?.login}</b> 
-                </p>
-                <p>
-                    Role: {(user?.admin)? <Tag color="purple">Admin</Tag> : <Tag color="purple">Member</Tag>}
-                </p>
-            </div>
-            <div style={{marginTop: "40px"}}>
-                <h2>Rate Limit</h2>
-                <p>Limit: {rateLimit?.limit}</p>
-                <p>Remaining: {rateLimit?.remaining}</p>
-                <p>Reset: {moment(rateLimit?.reset).fromNow()}</p>
-            </div>
+            <h1>Settings</h1>
+            <Descriptions title="User Info" column={1} style={{marginTop: "40px"}}>
+                <Descriptions.Item label="Login">
+                    <b>{user?.login}</b>
+                </Descriptions.Item>
+                <Descriptions.Item label="Login">
+                    {(user?.admin)? 
+                        <Tag color="purple">Admin</Tag> 
+                        : 
+                        <Tag color="purple">Member</Tag>}
+                </Descriptions.Item>
+            </Descriptions>
+            <Descriptions title="Rate Limit" style={{marginTop: "40px"}} column={2}>
+                <Descriptions.Item label="Limit">{rateLimit?.limit}</Descriptions.Item>
+                <Descriptions.Item label="Remaining">{rateLimit?.remaining}</Descriptions.Item>
+                <Descriptions.Item label="Reset">{moment(rateLimit?.reset).fromNow()}</Descriptions.Item>
+            </Descriptions>
             {(isSlackEnabled)?
                 <div style={{marginTop: "40px", marginBottom: "20px"}}>
                     <h2>Slack</h2>

--- a/ui/src/views/Settings.tsx
+++ b/ui/src/views/Settings.tsx
@@ -32,14 +32,14 @@ export default function Settings(): JSX.Element {
                 <Descriptions.Item label="Login">
                     <b>{user?.login}</b>
                 </Descriptions.Item>
-                <Descriptions.Item label="Login">
+                <Descriptions.Item label="Role">
                     {(user?.admin)? 
                         <Tag color="purple">Admin</Tag> 
                         : 
                         <Tag color="purple">Member</Tag>}
                 </Descriptions.Item>
             </Descriptions>
-            <Descriptions title="Rate Limit" style={{marginTop: "40px"}} column={2}>
+            <Descriptions title="Rate Limit" style={{marginTop: "40px"}} column={1}>
                 <Descriptions.Item label="Limit">{rateLimit?.limit}</Descriptions.Item>
                 <Descriptions.Item label="Remaining">{rateLimit?.remaining}</Descriptions.Item>
                 <Descriptions.Item label="Reset">{moment(rateLimit?.reset).fromNow()}</Descriptions.Item>

--- a/ui/src/views/Settings.tsx
+++ b/ui/src/views/Settings.tsx
@@ -1,21 +1,19 @@
 import { useEffect } from "react"
 import { shallowEqual } from "react-redux"
 import { Helmet } from "react-helmet"
-import { Avatar, Button, Tag, Descriptions } from "antd"
-import moment from "moment"
+import { Button, Tag, Descriptions, Input } from "antd"
 
 import { useAppSelector, useAppDispatch } from "../redux/hooks"
-import { fetchMe, fetchRateLimit, checkSlack } from "../redux/settings"
+import { fetchMe, checkSlack } from "../redux/settings"
 
 import Main from "./Main"
 
 export default function Settings(): JSX.Element {
-    const { user, rateLimit, isSlackEnabled } = useAppSelector(state => state.settings, shallowEqual)
+    const { user, isSlackEnabled } = useAppSelector(state => state.settings, shallowEqual)
     const dispatch = useAppDispatch()
 
     useEffect(() => {
         dispatch(fetchMe())
-        dispatch(fetchRateLimit())
         dispatch(checkSlack())
     }, [dispatch])
 
@@ -28,28 +26,32 @@ export default function Settings(): JSX.Element {
                 <title>Settings</title>
             </Helmet>
             <h1>Settings</h1>
-            <Descriptions title="User Info" column={1} style={{marginTop: "40px"}}>
-                <Descriptions.Item label="Login">
-                    <b>{user?.login}</b>
-                </Descriptions.Item>
+            <Descriptions title="User Info" column={2} style={{marginTop: "40px"}} layout="vertical">
+                <Descriptions.Item label="Login">{user?.login}</Descriptions.Item>
                 <Descriptions.Item label="Role">
                     {(user?.admin)? 
                         <Tag color="purple">Admin</Tag> 
                         : 
                         <Tag color="purple">Member</Tag>}
                 </Descriptions.Item>
-            </Descriptions>
-            <Descriptions title="Rate Limit" style={{marginTop: "40px"}} column={1}>
-                <Descriptions.Item label="Limit">{rateLimit?.limit}</Descriptions.Item>
-                <Descriptions.Item label="Remaining">{rateLimit?.remaining}</Descriptions.Item>
-                <Descriptions.Item label="Reset">{moment(rateLimit?.reset).fromNow()}</Descriptions.Item>
+                <Descriptions.Item label="Token">
+                    <Input.Password 
+                        value={user?.hash}
+                        style={{width: 200, padding:0 }}
+                        readOnly
+                        bordered={false}
+                    />
+                </Descriptions.Item>
             </Descriptions>
             {(isSlackEnabled)?
                 <div style={{marginTop: "40px", marginBottom: "20px"}}>
-                    <h2>Slack</h2>
-                    {(connected)? 
-                        <Button href="/slack/signout" type="primary" danger>DISCONNECTED</Button>:
-                        <Button href="/slack/" type="primary">CONNECT</Button>}
+                    <Descriptions title="Slack">
+                        <Descriptions.Item>
+                            {(connected)? 
+                                <Button href="/slack/signout" type="primary" danger>DISCONNECTED</Button>:
+                                <Button href="/slack/" type="primary">CONNECT</Button>}
+                        </Descriptions.Item>
+                    </Descriptions>
                 </div>:
                 null}
         </Main>


### PR DESCRIPTION
The `hash` value, which is sensitive information, is not exposed as an API by default. However, in order to expose it to the UI, it has been changed to be exposed only in the `/user` API.

![image](https://user-images.githubusercontent.com/17633736/155144216-3607ba55-1902-442a-9d65-26cb10d3a1eb.png)
