### PR TITLE
Fix the grid of `Main` view

### DIFF
--- a/ui/src/views/Main.tsx
+++ b/ui/src/views/Main.tsx
@@ -163,7 +163,9 @@ export default function Main(props: any) {
                         span={22}
                         offset={1}
                         md={{span: 14, offset: 5}} 
-                        lg={{span: 10, offset: 7}}>
+                        lg={{span: 12, offset: 6}} 
+                        xxl={{span: 10, offset: 7}}
+                    >
                         {content}
                     </Col>
                 </Row>


### PR DESCRIPTION
I've enlarged the grid for the size between `lg` and `xxl`, which is between 992px and 1600px. It resolves the phenomenon that the page is too small for a laptop (1280px).

<details>
<summary>screenshot</summary>

<img width="1440" alt="스크린샷 2022-03-12 오후 4 42 34" src="https://user-images.githubusercontent.com/17633736/158008939-db8bddf5-9d6a-4026-933b-cbb6159a8a2a.png">

</details>
