### PR TITLE
Add the `productionOnly` query parameter to search API

### DIFF
--- a/internal/interactor/deployment.go
+++ b/internal/interactor/deployment.go
@@ -39,10 +39,11 @@ type (
 	SearchDeploymentsOfUserOptions struct {
 		ListOptions
 
-		Statuses []deployment.Status
-		Owned    bool
-		From     time.Time
-		To       time.Time
+		Statuses       []deployment.Status
+		Owned          bool
+		ProductionOnly bool
+		From           time.Time
+		To             time.Time
 	}
 
 	// ListInactiveDeploymentsLessThanTimeOptions specifies the optional parameters that

--- a/internal/pkg/store/deployment.go
+++ b/internal/pkg/store/deployment.go
@@ -43,8 +43,8 @@ func (s *Store) SearchDeploymentsOfUser(ctx context.Context, u *ent.User, opt *i
 				deployment.And(
 					deployment.UserIDEQ(u.ID),
 					statusIn(opt.Statuses),
-					deployment.CreatedAtGTE(opt.From),
-					deployment.CreatedAtLT(opt.To),
+					deployment.CreatedAtGTE(opt.From.UTC()),
+					deployment.CreatedAtLT(opt.To.UTC()),
 				),
 			).
 			Order(ent.Desc(deployment.FieldCreatedAt)).
@@ -70,8 +70,8 @@ func (s *Store) SearchDeploymentsOfUser(ctx context.Context, u *ent.User, opt *i
 		Where(
 			deployment.And(
 				statusIn(opt.Statuses),
-				deployment.CreatedAtGTE(opt.From),
-				deployment.CreatedAtLT(opt.To),
+				deployment.CreatedAtGTE(opt.From.UTC()),
+				deployment.CreatedAtLT(opt.To.UTC()),
 			),
 		).
 		Order(ent.Desc(deployment.FieldCreatedAt)).

--- a/internal/server/api/v1/search/search.go
+++ b/internal/server/api/v1/search/search.go
@@ -115,8 +115,8 @@ func (s *Search) SearchDeployments(c *gin.Context) {
 		ListOptions: i.ListOptions{Page: p, PerPage: pp},
 		Statuses:    ss,
 		Owned:       o,
-		From:        f.UTC(),
-		To:          t.UTC(),
+		From:        f,
+		To:          t,
 	}); err != nil {
 		s.log.Check(gb.GetZapLogLevel(err), "Failed to search deployments.").Write(zap.Error(err))
 		gb.ResponseWithError(c, err)

--- a/model/ent/migrate/schema.go
+++ b/model/ent/migrate/schema.go
@@ -100,7 +100,7 @@ var (
 				Columns: []*schema.Column{DeploymentsColumns[7]},
 			},
 			{
-				Name:    "deployment_status_created_at",
+				Name:    "deployment_created_at_status",
 				Unique:  false,
 				Columns: []*schema.Column{DeploymentsColumns[6], DeploymentsColumns[12]},
 			},

--- a/model/ent/migrate/schema.go
+++ b/model/ent/migrate/schema.go
@@ -102,7 +102,7 @@ var (
 			{
 				Name:    "deployment_created_at_status",
 				Unique:  false,
-				Columns: []*schema.Column{DeploymentsColumns[6], DeploymentsColumns[12]},
+				Columns: []*schema.Column{DeploymentsColumns[12], DeploymentsColumns[6]},
 			},
 		},
 	}

--- a/model/ent/schema/deployment.go
+++ b/model/ent/schema/deployment.go
@@ -112,6 +112,7 @@ func (Deployment) Indexes() []ent.Index {
 		// Find by UID when the hook is coming.
 		index.Fields("uid"),
 		// List inactive deployments for 30 minutes.
-		index.Fields("status", "created_at"),
+		// Or search deployments that were created between the start time and the end time.
+		index.Fields("created_at", "status"),
 	}
 }


### PR DESCRIPTION
The `productionOnly` parameter is added to the API to retrieve only the deployments for the production environment. Related #382 