### PR TITLE
Add the `DynamicPayloadModal` to post the `dyanmic_payload`

### DIFF
--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -1869,8 +1869,9 @@ components:
         enabled:
           type: boolean
         inputs:
-          type: array
-          items:
+          # Dictionaries
+          type: object
+          additionalProperties:
             type: object
             properties:
               type:

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -1840,6 +1840,8 @@ components:
             type: string
         payload:
           type: string
+        dynamic_payload:
+          $ref: '#/components/schemas/DynamicPayload'
         production_environment:
           type: boolean
         review:
@@ -1861,6 +1863,38 @@ components:
         - auto_merge
         - payload
         - production_environment
+    DynamicPayload:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+        inputs:
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                enum:
+                  - select
+                  - number
+                  - string
+                  - boolean
+              required:
+                type: boolean
+              default:
+                anyOf:
+                  - type: number
+                  - type: string
+                  - type: boolean
+              description:
+                type: string
+              options:
+                type: array
+                items:
+                  type: string
+            required:
+              - type
     Reviews:
       type: array
       items:

--- a/ui/src/apis/config.ts
+++ b/ui/src/apis/config.ts
@@ -2,7 +2,7 @@ import { StatusCodes } from 'http-status-codes'
 
 import { instance, headers } from './setting'
 import { _fetch } from "./_base"
-import { Config, Env, DynamicPayloadInputTypeEnum, HttpNotFoundError } from '../models'
+import { Config, Env, HttpNotFoundError } from '../models'
 
 interface ConfigData {
     envs: EnvData[]
@@ -13,7 +13,7 @@ interface EnvData {
     required_contexts?: string[]
     dynamic_payload?: {
         enabled: boolean,
-        inputs: Map<string, any>,
+        inputs: any,
     }
     review?: {
         enabled: boolean

--- a/ui/src/apis/config.ts
+++ b/ui/src/apis/config.ts
@@ -2,7 +2,7 @@ import { StatusCodes } from 'http-status-codes'
 
 import { instance, headers } from './setting'
 import { _fetch } from "./_base"
-import { Config, Env, HttpNotFoundError } from '../models'
+import { Config, Env, DynamicPayloadInputTypeEnum, HttpNotFoundError } from '../models'
 
 interface ConfigData {
     envs: EnvData[]
@@ -11,6 +11,10 @@ interface ConfigData {
 interface EnvData {
     name: string
     required_contexts?: string[]
+    dynamic_payload?: {
+        enabled: boolean,
+        inputs: Map<string, any>,
+    }
     review?: {
         enabled: boolean
         reviewers: string[]
@@ -19,11 +23,15 @@ interface EnvData {
 
 const mapDataToConfig = (data: ConfigData): Config => {
     const envs: Env[] = data.envs.map((e: EnvData) => {
-        const { review } = e
+        const { dynamic_payload, review } = e
 
         return {
             name: e.name,
             requiredContexts: e.required_contexts,
+            dynamicPayload: (dynamic_payload)? {
+                enabled: dynamic_payload?.enabled,
+                inputs: dynamic_payload?.inputs,
+            } : undefined,
             review,
         }
     })

--- a/ui/src/apis/deployment.ts
+++ b/ui/src/apis/deployment.ts
@@ -191,11 +191,13 @@ export const getDeployment = async (namespace: string, name: string, number: num
     return deployment
 }
 
-export const createDeployment = async (namespace: string, name: string, type: DeploymentType = DeploymentType.Commit, ref: string, env: string): Promise<Deployment> => {
+// eslint-disable-next-line
+export const createDeployment = async (namespace: string, name: string, type: DeploymentType = DeploymentType.Commit, ref: string, env: string, payload?: any): Promise<Deployment> => {
     const body = JSON.stringify({
         type,
         ref,
-        env
+        env,
+        dynamic_payload: payload
     })
     const response = await _fetch(`${instance}/api/v1/repos/${namespace}/${name}/deployments`, {
         headers,

--- a/ui/src/components/DeployForm.tsx
+++ b/ui/src/components/DeployForm.tsx
@@ -182,7 +182,8 @@ export default function DeployForm(props: DeployFormProps): JSX.Element {
     return (
         <Form
             onFinish={onClickFinish}
-            name="deploy">
+            name="deploy"
+        >
             <Form.Item
                 {...selectLayout}
                 rules={[{required: true}]}

--- a/ui/src/components/DynamicPayloadModal.tsx
+++ b/ui/src/components/DynamicPayloadModal.tsx
@@ -1,0 +1,130 @@
+import { Modal, Form, Select, Input, InputNumber, Checkbox } from "antd"
+
+import { Env, DynamicPayloadInput, DynamicPayloadInputTypeEnum } from "../models"
+
+export interface DynamicPayloadModalProps {
+    visible: boolean
+    env: Env
+    onClickOk(values: any): void
+    onClickCancel(): void
+}
+
+export default function DynamicPayloadModal(props: DynamicPayloadModalProps): JSX.Element {
+    const [ form ] = Form.useForm()
+
+    const onClickOk = () => {
+        form.validateFields()
+            .then(values => {
+                props.onClickOk(values)
+            })
+            .catch(info => {
+                console.log(info)
+            })
+    }
+
+    const onClickCancel = () => {
+        props.onClickCancel()
+    }
+
+    // Build items dynamically
+    const items = new Array<JSX.Element>()
+    if (props.env.dynamicPayload) {
+        // Object.entries(props.env.dynamicPayload.inputs).forEach()
+        Object.entries(props.env.dynamicPayload.inputs).forEach((entry) => {
+            const [name, input] = entry
+            items.push(<DynamicItem key={name} name={name} input={input}/>)
+        })
+    }
+
+    // Build the initialValues
+    const initialValues: any = {}
+    if (props.env.dynamicPayload) {
+        Object.entries(props.env.dynamicPayload.inputs).forEach((entry) => {
+            const [name, input] = entry
+
+            if (input.default !== undefined) {
+                initialValues[name] = input.default
+            }
+        })
+    }
+
+    return (
+        <Modal
+            visible={props.visible}
+            onOk={onClickOk}
+            onCancel={onClickCancel}
+        >
+            <Form 
+                form={form} 
+                layout="vertical" 
+                name="dynamic_payload"
+                initialValues={initialValues}
+            >
+                {items.map(item => item)}
+            </Form>
+        </Modal>
+    )
+}
+
+interface DynamicItemProps {
+    name: string
+    input: DynamicPayloadInput
+}
+
+function DynamicItem({name, input}: DynamicItemProps): JSX.Element {
+    // Capitalize the first character.
+    const label = name.charAt(0).toUpperCase() + name.slice(1)
+    const description = input.description
+    const rules = (input.required)? [{required: true}] : []
+
+    switch (input.type) {
+        case DynamicPayloadInputTypeEnum.Select:
+            return (
+                <Form.Item
+                    label={label}
+                    name={name}
+                    tooltip={description}
+                    rules={rules}
+                >
+                    <Select >
+                        {input.options?.map((option: any, idx: any) => 
+                            <Select.Option key={idx} value={option}>{option}</Select.Option>
+                        )}
+                    </Select>
+                </Form.Item>
+            )
+        case DynamicPayloadInputTypeEnum.String:
+            return  (
+                <Form.Item
+                    label={label}
+                    name={name}
+                    tooltip={description}
+                    rules={rules}
+                >
+                    <Input />
+                </Form.Item>
+            )
+        case DynamicPayloadInputTypeEnum.Number:
+            return (
+                <Form.Item
+                    label={label}
+                    name={name}
+                    tooltip={description}
+                    rules={rules}
+                >
+                    <InputNumber />
+                </Form.Item>
+            )
+        case DynamicPayloadInputTypeEnum.Boolean:
+            return (
+                <Form.Item
+                    label={label}
+                    name={name}
+                    tooltip={description}
+                    rules={rules}
+                >
+                    <Checkbox />
+                </Form.Item>
+            )
+    }
+}

--- a/ui/src/components/DynamicPayloadModal.tsx
+++ b/ui/src/components/DynamicPayloadModal.tsx
@@ -41,10 +41,7 @@ export default function DynamicPayloadModal(props: DynamicPayloadModalProps): JS
     if (props.env.dynamicPayload) {
         Object.entries(props.env.dynamicPayload.inputs).forEach((entry) => {
             const [name, input] = entry
-
-            if (input.default !== undefined) {
-                initialValues[name] = input.default
-            }
+            initialValues[name] = input.default
         })
     }
 

--- a/ui/src/models/Config.ts
+++ b/ui/src/models/Config.ts
@@ -14,15 +14,17 @@ export interface Env {
 
 export interface DynamicPayload {
     enabled: boolean
-    inputs: Map<string, DynamicPayloadInput>
+    inputs: {
+        [key: string]: DynamicPayloadInput
+    }
 }
 
 export interface DynamicPayloadInput {
     type: DynamicPayloadInputTypeEnum
-    required: boolean
-    default: any
-    description: string
-    options: string[]
+    required?: boolean
+    default?: any
+    description?: string
+    options?: string[]
 }
 
 export enum DynamicPayloadInputTypeEnum {

--- a/ui/src/models/Config.ts
+++ b/ui/src/models/Config.ts
@@ -5,8 +5,29 @@ export default interface Config  {
 export interface Env {
     name: string
     requiredContexts?: string[]
+    dynamicPayload?: DynamicPayload
     review?: {
         enabled: boolean
         reviewers: string[]
     }
+}
+
+export interface DynamicPayload {
+    enabled: boolean
+    inputs: Map<string, DynamicPayloadInput>
+}
+
+export interface DynamicPayloadInput {
+    type: DynamicPayloadInputTypeEnum
+    required: boolean
+    default: any
+    description: string
+    options: string[]
+}
+
+export enum DynamicPayloadInputTypeEnum {
+    Select = "select",
+    String = "string",
+    Number = "number",
+    Boolean = "boolean"
 }

--- a/ui/src/models/index.ts
+++ b/ui/src/models/index.ts
@@ -5,7 +5,12 @@ import Deployment, {
     DeploymentType,
     DeploymentStatus,
 } from "./Deployment"
-import Config, { Env } from "./Config"
+import Config, { 
+    Env, 
+    DynamicPayload, 
+    DynamicPayloadInput,
+    DynamicPayloadInputTypeEnum 
+} from "./Config"
 import Commit, { Author, Status, StatusState } from "./Commit"
 import Branch from "./Branch"
 import Tag from "./Tag"
@@ -33,6 +38,8 @@ export type {
     DeploymentStatus,
     Config,
     Env,
+    DynamicPayload,
+    DynamicPayloadInput,
     Commit,
     Author,
     Status,
@@ -58,6 +65,7 @@ export {
     HttpUnprocessableEntityError,
     DeploymentStatusEnum,
     DeploymentType,
+    DynamicPayloadInputTypeEnum,
     StatusState,
     RequestStatus,
     ReviewStatusEnum,

--- a/ui/src/redux/repoDeploy.tsx
+++ b/ui/src/redux/repoDeploy.tsx
@@ -256,9 +256,9 @@ export const fetchUser = createAsyncThunk<User, void, { state: {repoDeploy: Repo
     }
 )
 
-export const deploy = createAsyncThunk<void, void, { state: {repoDeploy: RepoDeployState}}> (
+export const deploy = createAsyncThunk<void, any, { state: {repoDeploy: RepoDeployState}}> (
     "repoDeploy/deploy",
-    async (_ , { getState, rejectWithValue, requestId }) => {
+    async (payload, { getState, rejectWithValue, requestId }) => {
         const { namespace, name, env, type, branch, commit, tag, deploying, deployId } = getState().repoDeploy
         if (!env) {
             throw new Error("The env is undefined.")
@@ -271,11 +271,11 @@ export const deploy = createAsyncThunk<void, void, { state: {repoDeploy: RepoDep
         try {
             let deployment: Deployment
             if (type === DeploymentType.Commit && commit) {
-                deployment = await createDeployment(namespace, name, type, commit.sha, env.name)
+                deployment = await createDeployment(namespace, name, type, commit.sha, env.name, payload)
             } else if (type === DeploymentType.Branch && branch) {
-                deployment = await createDeployment(namespace, name, type, branch.name, env.name)
+                deployment = await createDeployment(namespace, name, type, branch.name, env.name, payload)
             } else if (type === DeploymentType.Tag && tag) {
-                deployment = await createDeployment(namespace, name, type, tag.name, env.name)
+                deployment = await createDeployment(namespace, name, type, tag.name, env.name, payload)
             } else {
                 throw new Error("The type should be one of them: commit, branch, and tag.")
             }


### PR DESCRIPTION
The UI allows you to dynamically insert a payload value if the `dynamic_payload` field is enabled. The UI for the example YAML is as below:

<details>
<summary>예제</summary>

```yaml
envs:
  - name: dev
    auto_merge: false
    required_contexts: []
    dynamic_payload:
      enabled: true
      inputs:
        foo:
          type: select
          options:
            - one
            - two
          description: 'foo'     
          required: true
          default: 'one' 
        bar:
          type: string
          required: true
          default: 'baz'
        qux:
          type: number
          default: 0
```

![스크린샷 2022-04-02 오후 5 17 31](https://user-images.githubusercontent.com/17633736/161374495-931d0322-04a5-4859-b80b-d6a1c7b10009.png)

</details>