### PR TITLE
Enhance the notification message

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -80,6 +80,8 @@ require (
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
 	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/tools v0.1.9-0.20211216111533-8d383106f7e7 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -882,6 +882,7 @@ golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.9-0.20211216111533-8d383106f7e7 h1:M1gcVrIb2lSn2FIL19DG0+/b8nNVKJ7W7b4WcAGZAYM=
 golang.org/x/tools v0.1.9-0.20211216111533-8d383106f7e7/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/interactor/deployment.go
+++ b/internal/interactor/deployment.go
@@ -125,6 +125,7 @@ func (i *DeploymentInteractor) Deploy(ctx context.Context, u *ent.User, r *ent.R
 			Status:       string(deployment.StatusWaiting),
 			Description:  "Gitploy waits the reviews.",
 			DeploymentID: d.ID,
+			RepoID:       r.ID,
 		}); err != nil {
 			i.log.Error("Failed to create a deployment status.", zap.Error(err))
 		}
@@ -153,6 +154,7 @@ func (i *DeploymentInteractor) Deploy(ctx context.Context, u *ent.User, r *ent.R
 		Status:       string(deployment.StatusCreated),
 		Description:  "Gitploy starts to deploy.",
 		DeploymentID: d.ID,
+		RepoID:       r.ID,
 	}); err != nil {
 		i.log.Error("Failed to create a deployment status.", zap.Error(err))
 	}
@@ -235,6 +237,7 @@ func (i *DeploymentInteractor) DeployToRemote(ctx context.Context, u *ent.User, 
 		Status:       string(deployment.StatusCreated),
 		Description:  "Gitploy start to deploy.",
 		DeploymentID: d.ID,
+		RepoID:       r.ID,
 	})
 
 	return d, nil
@@ -301,6 +304,7 @@ L:
 							Status:       "canceled",
 							Description:  "Gitploy cancels the inactive deployment.",
 							DeploymentID: d.ID,
+							RepoID:       d.RepoID,
 						}
 						if err := i.scm.CancelDeployment(ctx, d.Edges.User, d.Edges.Repo, d, s); err != nil {
 							i.log.Error("It has failed to cancel the remote deployment.", zap.Error(err))

--- a/internal/interactor/deployment_test.go
+++ b/internal/interactor/deployment_test.go
@@ -57,7 +57,7 @@ func TestInteractor_Deploy(t *testing.T) {
 
 		store.
 			EXPECT().
-			CreateDeploymentStatus(ctx, gomock.AssignableToTypeOf(&ent.DeploymentStatus{}))
+			CreateEntDeploymentStatus(ctx, gomock.AssignableToTypeOf(&ent.DeploymentStatus{}))
 
 		it := i.NewInteractor(&i.InteractorConfig{
 			Store: store,
@@ -160,7 +160,7 @@ func TestInteractor_DeployToRemote(t *testing.T) {
 
 		store.
 			EXPECT().
-			CreateDeploymentStatus(ctx, gomock.AssignableToTypeOf(&ent.DeploymentStatus{}))
+			CreateEntDeploymentStatus(ctx, gomock.AssignableToTypeOf(&ent.DeploymentStatus{}))
 
 		it := i.NewInteractor(&i.InteractorConfig{
 			Store: store,

--- a/internal/interactor/deployment_test.go
+++ b/internal/interactor/deployment_test.go
@@ -52,12 +52,13 @@ func TestInteractor_Deploy(t *testing.T) {
 
 		store.
 			EXPECT().
-			CreateEvent(gomock.Any(), gomock.AssignableToTypeOf(&ent.Event{})).
-			Return(&ent.Event{}, nil)
+			CreateEntDeploymentStatus(ctx, gomock.AssignableToTypeOf(&ent.DeploymentStatus{})).
+			Return(&ent.DeploymentStatus{}, nil)
 
 		store.
 			EXPECT().
-			CreateEntDeploymentStatus(ctx, gomock.AssignableToTypeOf(&ent.DeploymentStatus{}))
+			CreateEvent(gomock.Any(), gomock.AssignableToTypeOf(&ent.Event{})).
+			Return(&ent.Event{}, nil)
 
 		it := i.NewInteractor(&i.InteractorConfig{
 			Store: store,
@@ -98,6 +99,11 @@ func TestInteractor_Deploy(t *testing.T) {
 			DoAndReturn(func(ctx context.Context, d *ent.Deployment) (interface{}, interface{}) {
 				return d, nil
 			})
+
+		store.
+			EXPECT().
+			CreateEntDeploymentStatus(ctx, gomock.AssignableToTypeOf(&ent.DeploymentStatus{})).
+			Return(&ent.DeploymentStatus{}, nil)
 
 		store.
 			EXPECT().
@@ -160,7 +166,13 @@ func TestInteractor_DeployToRemote(t *testing.T) {
 
 		store.
 			EXPECT().
-			CreateEntDeploymentStatus(ctx, gomock.AssignableToTypeOf(&ent.DeploymentStatus{}))
+			CreateEntDeploymentStatus(ctx, gomock.AssignableToTypeOf(&ent.DeploymentStatus{})).
+			Return(&ent.DeploymentStatus{}, nil)
+
+		store.
+			EXPECT().
+			CreateEvent(gomock.Any(), gomock.AssignableToTypeOf(&ent.Event{})).
+			Return(&ent.Event{}, nil)
 
 		it := i.NewInteractor(&i.InteractorConfig{
 			Store: store,

--- a/internal/interactor/interface.go
+++ b/internal/interactor/interface.go
@@ -43,8 +43,9 @@ type (
 	// PermStore defines operations for working with deployment_statuses.
 	DeploymentStatusStore interface {
 		ListDeploymentStatuses(ctx context.Context, d *ent.Deployment) ([]*ent.DeploymentStatus, error)
-		CreateDeploymentStatus(ctx context.Context, s *ent.DeploymentStatus) (*ent.DeploymentStatus, error)
-		SyncDeploymentStatus(ctx context.Context, ds *ent.DeploymentStatus) (*ent.DeploymentStatus, error)
+		// CreateEntDeploymentStatus create a DeploymentStatus entity to the store.
+		// Ent is appended to distinguish it from the interactor.
+		CreateEntDeploymentStatus(ctx context.Context, s *ent.DeploymentStatus) (*ent.DeploymentStatus, error)
 	}
 
 	SCM interface {

--- a/internal/interactor/interface.go
+++ b/internal/interactor/interface.go
@@ -43,6 +43,7 @@ type (
 	// PermStore defines operations for working with deployment_statuses.
 	DeploymentStatusStore interface {
 		ListDeploymentStatuses(ctx context.Context, d *ent.Deployment) ([]*ent.DeploymentStatus, error)
+		FindDeploymentStatusByID(ctx context.Context, id int) (*ent.DeploymentStatus, error)
 		// CreateEntDeploymentStatus create a DeploymentStatus entity to the store.
 		// Ent is appended to distinguish it from the interactor.
 		CreateEntDeploymentStatus(ctx context.Context, s *ent.DeploymentStatus) (*ent.DeploymentStatus, error)

--- a/internal/interactor/mock/pkg.go
+++ b/internal/interactor/mock/pkg.go
@@ -409,6 +409,21 @@ func (mr *MockStoreMockRecorder) FindDeploymentStatisticsOfRepoByEnv(ctx, r, env
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindDeploymentStatisticsOfRepoByEnv", reflect.TypeOf((*MockStore)(nil).FindDeploymentStatisticsOfRepoByEnv), ctx, r, env)
 }
 
+// FindDeploymentStatusByID mocks base method.
+func (m *MockStore) FindDeploymentStatusByID(ctx context.Context, id int) (*ent.DeploymentStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindDeploymentStatusByID", ctx, id)
+	ret0, _ := ret[0].(*ent.DeploymentStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindDeploymentStatusByID indicates an expected call of FindDeploymentStatusByID.
+func (mr *MockStoreMockRecorder) FindDeploymentStatusByID(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindDeploymentStatusByID", reflect.TypeOf((*MockStore)(nil).FindDeploymentStatusByID), ctx, id)
+}
+
 // FindLockByID mocks base method.
 func (m *MockStore) FindLockByID(ctx context.Context, id int) (*ent.Lock, error) {
 	m.ctrl.T.Helper()
@@ -1113,6 +1128,21 @@ func (m *MockDeploymentStatusStore) CreateEntDeploymentStatus(ctx context.Contex
 func (mr *MockDeploymentStatusStoreMockRecorder) CreateEntDeploymentStatus(ctx, s interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEntDeploymentStatus", reflect.TypeOf((*MockDeploymentStatusStore)(nil).CreateEntDeploymentStatus), ctx, s)
+}
+
+// FindDeploymentStatusByID mocks base method.
+func (m *MockDeploymentStatusStore) FindDeploymentStatusByID(ctx context.Context, id int) (*ent.DeploymentStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindDeploymentStatusByID", ctx, id)
+	ret0, _ := ret[0].(*ent.DeploymentStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindDeploymentStatusByID indicates an expected call of FindDeploymentStatusByID.
+func (mr *MockDeploymentStatusStoreMockRecorder) FindDeploymentStatusByID(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindDeploymentStatusByID", reflect.TypeOf((*MockDeploymentStatusStore)(nil).FindDeploymentStatusByID), ctx, id)
 }
 
 // ListDeploymentStatuses mocks base method.

--- a/internal/interactor/mock/pkg.go
+++ b/internal/interactor/mock/pkg.go
@@ -172,19 +172,19 @@ func (mr *MockStoreMockRecorder) CreateDeploymentStatistics(ctx, s interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDeploymentStatistics", reflect.TypeOf((*MockStore)(nil).CreateDeploymentStatistics), ctx, s)
 }
 
-// CreateDeploymentStatus mocks base method.
-func (m *MockStore) CreateDeploymentStatus(ctx context.Context, s *ent.DeploymentStatus) (*ent.DeploymentStatus, error) {
+// CreateEntDeploymentStatus mocks base method.
+func (m *MockStore) CreateEntDeploymentStatus(ctx context.Context, s *ent.DeploymentStatus) (*ent.DeploymentStatus, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateDeploymentStatus", ctx, s)
+	ret := m.ctrl.Call(m, "CreateEntDeploymentStatus", ctx, s)
 	ret0, _ := ret[0].(*ent.DeploymentStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CreateDeploymentStatus indicates an expected call of CreateDeploymentStatus.
-func (mr *MockStoreMockRecorder) CreateDeploymentStatus(ctx, s interface{}) *gomock.Call {
+// CreateEntDeploymentStatus indicates an expected call of CreateEntDeploymentStatus.
+func (mr *MockStoreMockRecorder) CreateEntDeploymentStatus(ctx, s interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDeploymentStatus", reflect.TypeOf((*MockStore)(nil).CreateDeploymentStatus), ctx, s)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEntDeploymentStatus", reflect.TypeOf((*MockStore)(nil).CreateEntDeploymentStatus), ctx, s)
 }
 
 // CreateEvent mocks base method.
@@ -844,21 +844,6 @@ func (mr *MockStoreMockRecorder) SearchUsers(ctx, opts interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchUsers", reflect.TypeOf((*MockStore)(nil).SearchUsers), ctx, opts)
 }
 
-// SyncDeploymentStatus mocks base method.
-func (m *MockStore) SyncDeploymentStatus(ctx context.Context, ds *ent.DeploymentStatus) (*ent.DeploymentStatus, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SyncDeploymentStatus", ctx, ds)
-	ret0, _ := ret[0].(*ent.DeploymentStatus)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SyncDeploymentStatus indicates an expected call of SyncDeploymentStatus.
-func (mr *MockStoreMockRecorder) SyncDeploymentStatus(ctx, ds interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncDeploymentStatus", reflect.TypeOf((*MockStore)(nil).SyncDeploymentStatus), ctx, ds)
-}
-
 // SyncRepo mocks base method.
 func (m *MockStore) SyncRepo(ctx context.Context, r *extent.RemoteRepo) (*ent.Repo, error) {
 	m.ctrl.T.Helper()
@@ -1115,19 +1100,19 @@ func (m *MockDeploymentStatusStore) EXPECT() *MockDeploymentStatusStoreMockRecor
 	return m.recorder
 }
 
-// CreateDeploymentStatus mocks base method.
-func (m *MockDeploymentStatusStore) CreateDeploymentStatus(ctx context.Context, s *ent.DeploymentStatus) (*ent.DeploymentStatus, error) {
+// CreateEntDeploymentStatus mocks base method.
+func (m *MockDeploymentStatusStore) CreateEntDeploymentStatus(ctx context.Context, s *ent.DeploymentStatus) (*ent.DeploymentStatus, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateDeploymentStatus", ctx, s)
+	ret := m.ctrl.Call(m, "CreateEntDeploymentStatus", ctx, s)
 	ret0, _ := ret[0].(*ent.DeploymentStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CreateDeploymentStatus indicates an expected call of CreateDeploymentStatus.
-func (mr *MockDeploymentStatusStoreMockRecorder) CreateDeploymentStatus(ctx, s interface{}) *gomock.Call {
+// CreateEntDeploymentStatus indicates an expected call of CreateEntDeploymentStatus.
+func (mr *MockDeploymentStatusStoreMockRecorder) CreateEntDeploymentStatus(ctx, s interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDeploymentStatus", reflect.TypeOf((*MockDeploymentStatusStore)(nil).CreateDeploymentStatus), ctx, s)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEntDeploymentStatus", reflect.TypeOf((*MockDeploymentStatusStore)(nil).CreateEntDeploymentStatus), ctx, s)
 }
 
 // ListDeploymentStatuses mocks base method.
@@ -1143,21 +1128,6 @@ func (m *MockDeploymentStatusStore) ListDeploymentStatuses(ctx context.Context, 
 func (mr *MockDeploymentStatusStoreMockRecorder) ListDeploymentStatuses(ctx, d interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDeploymentStatuses", reflect.TypeOf((*MockDeploymentStatusStore)(nil).ListDeploymentStatuses), ctx, d)
-}
-
-// SyncDeploymentStatus mocks base method.
-func (m *MockDeploymentStatusStore) SyncDeploymentStatus(ctx context.Context, ds *ent.DeploymentStatus) (*ent.DeploymentStatus, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SyncDeploymentStatus", ctx, ds)
-	ret0, _ := ret[0].(*ent.DeploymentStatus)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SyncDeploymentStatus indicates an expected call of SyncDeploymentStatus.
-func (mr *MockDeploymentStatusStoreMockRecorder) SyncDeploymentStatus(ctx, ds interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncDeploymentStatus", reflect.TypeOf((*MockDeploymentStatusStore)(nil).SyncDeploymentStatus), ctx, ds)
 }
 
 // MockSCM is a mock of SCM interface.

--- a/internal/pkg/store/deploymentstatus.go
+++ b/internal/pkg/store/deploymentstatus.go
@@ -49,3 +49,12 @@ func (s *Store) CreateEntDeploymentStatus(ctx context.Context, ds *ent.Deploymen
 
 	return ret, nil
 }
+
+func (s *Store) FindDeploymentStatusByID(ctx context.Context, id int) (*ent.DeploymentStatus, error) {
+	ds, err := s.c.DeploymentStatus.Get(ctx, id)
+	if ent.IsNotFound(err) {
+		return nil, e.NewError(e.ErrorCodeEntityNotFound, err)
+	}
+
+	return ds, nil
+}

--- a/internal/pkg/store/deploymentstatus.go
+++ b/internal/pkg/store/deploymentstatus.go
@@ -21,40 +21,27 @@ func (s *Store) ListDeploymentStatuses(ctx context.Context, d *ent.Deployment) (
 	return dss, nil
 }
 
-func (s *Store) CreateDeploymentStatus(ctx context.Context, ds *ent.DeploymentStatus) (*ent.DeploymentStatus, error) {
-	ret, err := s.c.DeploymentStatus.
-		Create().
+func (s *Store) CreateEntDeploymentStatus(ctx context.Context, ds *ent.DeploymentStatus) (*ent.DeploymentStatus, error) {
+	// Build the query creating a deployment status.
+	qry := s.c.DeploymentStatus.Create().
 		SetStatus(ds.Status).
 		SetDescription(ds.Description).
 		SetLogURL(ds.LogURL).
-		SetDeploymentID(ds.DeploymentID).
-		Save(ctx)
+		SetDeploymentID(ds.DeploymentID)
+
+	if !ds.CreatedAt.IsZero() {
+		qry.SetCreatedAt(ds.CreatedAt.UTC())
+	}
+
+	if !ds.UpdatedAt.IsZero() {
+		qry.SetUpdatedAt(ds.UpdatedAt.UTC())
+	}
+
+	ret, err := qry.Save(ctx)
 	if ent.IsConstraintError(err) {
 		return nil, e.NewErrorWithMessage(
 			e.ErrorCodeEntityUnprocessable,
 			fmt.Sprintf("Failed to create a deployment status. The value of \"%s\" field is invalid.", err.(*ent.ValidationError).Name),
-			err)
-	} else if err != nil {
-		return nil, e.NewError(e.ErrorCodeInternalError, err)
-	}
-
-	return ret, nil
-}
-
-func (s *Store) SyncDeploymentStatus(ctx context.Context, ds *ent.DeploymentStatus) (*ent.DeploymentStatus, error) {
-	ret, err := s.c.DeploymentStatus.
-		Create().
-		SetStatus(ds.Status).
-		SetDescription(ds.Description).
-		SetLogURL(ds.LogURL).
-		SetDeploymentID(ds.DeploymentID).
-		SetCreatedAt(ds.CreatedAt).
-		SetUpdatedAt(ds.UpdatedAt).
-		Save(ctx)
-	if ent.IsConstraintError(err) {
-		return nil, e.NewErrorWithMessage(
-			e.ErrorCodeEntityUnprocessable,
-			fmt.Sprintf("Failed to sync the deployment status. The value of \"%s\" field is invalid.", err.(*ent.ValidationError).Name),
 			err)
 	} else if err != nil {
 		return nil, e.NewError(e.ErrorCodeInternalError, err)

--- a/internal/pkg/store/event.go
+++ b/internal/pkg/store/event.go
@@ -47,10 +47,8 @@ func (s *Store) CreateEvent(ctx context.Context, e *ent.Event) (*ent.Event, erro
 		SetKind(e.Kind).
 		SetType(e.Type)
 
-	if e.Type == event.TypeDeleted {
-		qry = qry.SetDeletedID(e.DeletedID)
-	} else if e.Kind == event.KindDeployment {
-		qry = qry.SetDeploymentID(e.DeploymentID)
+	if e.Kind == event.KindDeploymentStatus {
+		qry = qry.SetDeploymentStatusID(e.DeploymentStatusID)
 	} else if e.Kind == event.KindReview {
 		qry = qry.SetReviewID(e.ReviewID)
 	}

--- a/internal/pkg/store/event.go
+++ b/internal/pkg/store/event.go
@@ -28,6 +28,10 @@ func (s *Store) ListEventsGreaterThanTime(ctx context.Context, t time.Time) ([]*
 				WithRepo().
 				WithDeploymentStatuses()
 		}).
+		WithDeploymentStatus(func(dsq *ent.DeploymentStatusQuery) {
+			dsq.
+				WithDeployment()
+		}).
 		WithReview(func(rq *ent.ReviewQuery) {
 			rq.
 				WithUser().

--- a/internal/pkg/store/event.go
+++ b/internal/pkg/store/event.go
@@ -30,7 +30,8 @@ func (s *Store) ListEventsGreaterThanTime(ctx context.Context, t time.Time) ([]*
 		}).
 		WithDeploymentStatus(func(dsq *ent.DeploymentStatusQuery) {
 			dsq.
-				WithDeployment()
+				WithDeployment().
+				WithRepo()
 		}).
 		WithReview(func(rq *ent.ReviewQuery) {
 			rq.

--- a/internal/pkg/store/event.go
+++ b/internal/pkg/store/event.go
@@ -22,12 +22,6 @@ func (s *Store) ListEventsGreaterThanTime(ctx context.Context, t time.Time) ([]*
 		Where(
 			event.CreatedAtGT(t),
 		).
-		WithDeployment(func(dq *ent.DeploymentQuery) {
-			dq.
-				WithUser().
-				WithRepo().
-				WithDeploymentStatuses()
-		}).
 		WithDeploymentStatus(func(dsq *ent.DeploymentStatusQuery) {
 			dsq.
 				WithDeployment().

--- a/internal/pkg/store/event_test.go
+++ b/internal/pkg/store/event_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestStore_CreateEvent(t *testing.T) {
 
-	t.Run("Create a new deleted event", func(t *testing.T) {
+	t.Run("Create a new deployment_status event", func(t *testing.T) {
 		ctx := context.Background()
 
 		client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1",
@@ -22,17 +22,13 @@ func TestStore_CreateEvent(t *testing.T) {
 
 		s := NewStore(client)
 
-		e, err := s.CreateEvent(ctx, &ent.Event{
-			Kind:      event.KindReview,
-			Type:      event.TypeDeleted,
-			DeletedID: 1,
+		_, err := s.CreateEvent(ctx, &ent.Event{
+			Kind:               event.KindDeploymentStatus,
+			Type:               event.TypeCreated,
+			DeploymentStatusID: 1,
 		})
 		if err != nil {
 			t.Fatalf("CreateEvent returns an error: %s", err)
-		}
-
-		if e.DeletedID != 1 {
-			t.Fatalf("event.DeletedID = %v, wanted %v", e.DeletedID, 1)
 		}
 	})
 }

--- a/internal/server/api/v1/repos/interface.go
+++ b/internal/server/api/v1/repos/interface.go
@@ -48,8 +48,6 @@ type (
 		UpdateLock(ctx context.Context, l *ent.Lock) (*ent.Lock, error)
 		DeleteLock(ctx context.Context, l *ent.Lock) error
 
-		CreateEvent(ctx context.Context, e *ent.Event) (*ent.Event, error)
-
 		ListCommits(ctx context.Context, u *ent.User, r *ent.Repo, branch string, opt *i.ListOptions) ([]*extent.Commit, error)
 		CompareCommits(ctx context.Context, u *ent.User, r *ent.Repo, base, head string, opt *i.ListOptions) ([]*extent.Commit, []*extent.CommitFile, error)
 		GetCommit(ctx context.Context, u *ent.User, r *ent.Repo, sha string) (*extent.Commit, error)

--- a/internal/server/api/v1/repos/mock/interactor.go
+++ b/internal/server/api/v1/repos/mock/interactor.go
@@ -68,21 +68,6 @@ func (mr *MockInteractorMockRecorder) CompareCommits(ctx, u, r, base, head, opt 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompareCommits", reflect.TypeOf((*MockInteractor)(nil).CompareCommits), ctx, u, r, base, head, opt)
 }
 
-// CreateEvent mocks base method.
-func (m *MockInteractor) CreateEvent(ctx context.Context, e *ent.Event) (*ent.Event, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateEvent", ctx, e)
-	ret0, _ := ret[0].(*ent.Event)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateEvent indicates an expected call of CreateEvent.
-func (mr *MockInteractorMockRecorder) CreateEvent(ctx, e interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEvent", reflect.TypeOf((*MockInteractor)(nil).CreateEvent), ctx, e)
-}
-
 // CreateLock mocks base method.
 func (m *MockInteractor) CreateLock(ctx context.Context, l *ent.Lock) (*ent.Lock, error) {
 	m.ctrl.T.Helper()

--- a/internal/server/api/v1/stream/events.go
+++ b/internal/server/api/v1/stream/events.go
@@ -39,7 +39,7 @@ func (s *Stream) GetEvents(c *gin.Context) {
 			}
 
 			if _, err := s.i.FindPermOfRepo(ctx, d.Edges.Repo, u); err != nil {
-				s.log.Debug("Skip the event. The permission is denied.")
+				s.log.Debug("Skip the event. The permission is denied.", zap.Error(err))
 				return
 			}
 
@@ -47,6 +47,30 @@ func (s *Stream) GetEvents(c *gin.Context) {
 			events <- &sse.Event{
 				Event: "deployment",
 				Data:  d,
+			}
+		case event.KindDeploymentStatus:
+			ds, err := s.i.FindDeploymentStatusByID(ctx, e.DeploymentStatusID)
+			if err != nil {
+				s.log.Error("Failed to find the deployment status.", zap.Error(err))
+				return
+			}
+
+			// Ensure that a user has access to the repository of the deployment.
+			d, err := s.i.FindDeploymentByID(ctx, ds.DeploymentID)
+			if err != nil {
+				s.log.Error("Failed to find the deployment.", zap.Error(err))
+				return
+			}
+
+			if _, err := s.i.FindPermOfRepo(ctx, d.Edges.Repo, u); err != nil {
+				s.log.Debug("Skip the event. The permission is denied.", zap.Error(err))
+				return
+			}
+
+			s.log.Debug("Dispatch a deployment_status event.", zap.Int("id", d.ID))
+			events <- &sse.Event{
+				Event: "deployment_status",
+				Data:  ds,
 			}
 
 		case event.KindReview:

--- a/internal/server/api/v1/stream/events.go
+++ b/internal/server/api/v1/stream/events.go
@@ -31,23 +31,6 @@ func (s *Stream) GetEvents(c *gin.Context) {
 	// it'll unsubscribe after the connection is closed.
 	sub := func(e *ent.Event) {
 		switch e.Kind {
-		case event.KindDeployment:
-			d, err := s.i.FindDeploymentByID(ctx, e.DeploymentID)
-			if err != nil {
-				s.log.Error("Failed to find the deployment.", zap.Error(err))
-				return
-			}
-
-			if _, err := s.i.FindPermOfRepo(ctx, d.Edges.Repo, u); err != nil {
-				s.log.Debug("Skip the event. The permission is denied.", zap.Error(err))
-				return
-			}
-
-			s.log.Debug("Dispatch a deployment event.", zap.Int("id", d.ID))
-			events <- &sse.Event{
-				Event: "deployment",
-				Data:  d,
-			}
 		case event.KindDeploymentStatus:
 			ds, err := s.i.FindDeploymentStatusByID(ctx, e.DeploymentStatusID)
 			if err != nil {

--- a/internal/server/api/v1/stream/interface.go
+++ b/internal/server/api/v1/stream/interface.go
@@ -11,6 +11,7 @@ type (
 		SubscribeEvent(fn func(e *ent.Event)) error
 		UnsubscribeEvent(fn func(e *ent.Event)) error
 		FindDeploymentByID(ctx context.Context, id int) (*ent.Deployment, error)
+		FindDeploymentStatusByID(ctx context.Context, id int) (*ent.DeploymentStatus, error)
 		FindReviewByID(ctx context.Context, id int) (*ent.Review, error)
 		FindPermOfRepo(ctx context.Context, r *ent.Repo, u *ent.User) (*ent.Perm, error)
 	}

--- a/internal/server/hooks/hook.go
+++ b/internal/server/hooks/hook.go
@@ -12,7 +12,6 @@ import (
 	gb "github.com/gitploy-io/gitploy/internal/server/global"
 	"github.com/gitploy-io/gitploy/model/ent"
 	"github.com/gitploy-io/gitploy/model/ent/deployment"
-	"github.com/gitploy-io/gitploy/model/ent/event"
 	"github.com/gitploy-io/gitploy/model/extent"
 	"github.com/gitploy-io/gitploy/pkg/e"
 )
@@ -118,7 +117,7 @@ func (h *Hooks) handleGithubDeploymentEvent(c *gin.Context) {
 	}
 
 	ds.DeploymentID = d.ID
-	if ds, err = h.i.SyncDeploymentStatus(ctx, ds); err != nil {
+	if ds, err = h.i.CreateDeploymentStatus(ctx, ds); err != nil {
 		h.log.Check(gb.GetZapLogLevel(err), "Failed to create a new the deployment status.").Write(zap.Error(err))
 		gb.ResponseWithError(c, err)
 		return
@@ -129,14 +128,6 @@ func (h *Hooks) handleGithubDeploymentEvent(c *gin.Context) {
 		h.log.Check(gb.GetZapLogLevel(err), "Failed to update the deployment.").Write(zap.Error(err))
 		gb.ResponseWithError(c, err)
 		return
-	}
-
-	if _, err := h.i.CreateEvent(ctx, &ent.Event{
-		Kind:         event.KindDeployment,
-		Type:         event.TypeUpdated,
-		DeploymentID: d.ID,
-	}); err != nil {
-		h.log.Error("It has failed to create the event.", zap.Error(err))
 	}
 
 	// Produce statistics when the deployment is success, and production environment.

--- a/internal/server/hooks/hook.go
+++ b/internal/server/hooks/hook.go
@@ -117,6 +117,7 @@ func (h *Hooks) handleGithubDeploymentEvent(c *gin.Context) {
 	}
 
 	ds.DeploymentID = d.ID
+	ds.RepoID = d.RepoID
 	if ds, err = h.i.CreateDeploymentStatus(ctx, ds); err != nil {
 		h.log.Check(gb.GetZapLogLevel(err), "Failed to create a new the deployment status.").Write(zap.Error(err))
 		gb.ResponseWithError(c, err)

--- a/internal/server/hooks/hook_test.go
+++ b/internal/server/hooks/hook_test.go
@@ -46,7 +46,7 @@ func TestHook_HandleHook(t *testing.T) {
 
 		m.
 			EXPECT().
-			SyncDeploymentStatus(gomock.Any(), gomock.Eq(&ent.DeploymentStatus{
+			CreateDeploymentStatus(gomock.Any(), gomock.Eq(&ent.DeploymentStatus{
 				Status:       *e.DeploymentStatus.State,
 				Description:  *e.DeploymentStatus.Description,
 				CreatedAt:    e.DeploymentStatus.CreatedAt.Time.UTC(),
@@ -74,11 +74,6 @@ func TestHook_HandleHook(t *testing.T) {
 				UID:    *e.Deployment.ID,
 				Status: deployment.StatusSuccess,
 			}, nil)
-
-		m.
-			EXPECT().
-			CreateEvent(gomock.Any(), gomock.Any()).
-			Return(&ent.Event{}, nil)
 
 		h := NewHooks(&ConfigHooks{}, m)
 		r := gin.New()

--- a/internal/server/hooks/interface.go
+++ b/internal/server/hooks/interface.go
@@ -13,11 +13,10 @@ type (
 	Interactor interface {
 		FindRepoByID(ctx context.Context, id int64) (*ent.Repo, error)
 		FindDeploymentByUID(ctx context.Context, uid int64) (*ent.Deployment, error)
-		SyncDeploymentStatus(ctx context.Context, ds *ent.DeploymentStatus) (*ent.DeploymentStatus, error)
 		Deploy(ctx context.Context, u *ent.User, r *ent.Repo, d *ent.Deployment, env *extent.Env) (*ent.Deployment, error)
 		UpdateDeployment(ctx context.Context, d *ent.Deployment) (*ent.Deployment, error)
+		CreateDeploymentStatus(ctx context.Context, ds *ent.DeploymentStatus) (*ent.DeploymentStatus, error)
 		ProduceDeploymentStatisticsOfRepo(ctx context.Context, r *ent.Repo, d *ent.Deployment) (*ent.DeploymentStatistics, error)
-		CreateEvent(ctx context.Context, e *ent.Event) (*ent.Event, error)
 		GetEvaluatedConfig(ctx context.Context, u *ent.User, r *ent.Repo, v *extent.EvalValues) (*extent.Config, error)
 	}
 )

--- a/internal/server/hooks/mock/interactor.go
+++ b/internal/server/hooks/mock/interactor.go
@@ -36,19 +36,19 @@ func (m *MockInteractor) EXPECT() *MockInteractorMockRecorder {
 	return m.recorder
 }
 
-// CreateEvent mocks base method.
-func (m *MockInteractor) CreateEvent(ctx context.Context, e *ent.Event) (*ent.Event, error) {
+// CreateDeploymentStatus mocks base method.
+func (m *MockInteractor) CreateDeploymentStatus(ctx context.Context, ds *ent.DeploymentStatus) (*ent.DeploymentStatus, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateEvent", ctx, e)
-	ret0, _ := ret[0].(*ent.Event)
+	ret := m.ctrl.Call(m, "CreateDeploymentStatus", ctx, ds)
+	ret0, _ := ret[0].(*ent.DeploymentStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CreateEvent indicates an expected call of CreateEvent.
-func (mr *MockInteractorMockRecorder) CreateEvent(ctx, e interface{}) *gomock.Call {
+// CreateDeploymentStatus indicates an expected call of CreateDeploymentStatus.
+func (mr *MockInteractorMockRecorder) CreateDeploymentStatus(ctx, ds interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEvent", reflect.TypeOf((*MockInteractor)(nil).CreateEvent), ctx, e)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDeploymentStatus", reflect.TypeOf((*MockInteractor)(nil).CreateDeploymentStatus), ctx, ds)
 }
 
 // Deploy mocks base method.
@@ -124,21 +124,6 @@ func (m *MockInteractor) ProduceDeploymentStatisticsOfRepo(ctx context.Context, 
 func (mr *MockInteractorMockRecorder) ProduceDeploymentStatisticsOfRepo(ctx, r, d interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProduceDeploymentStatisticsOfRepo", reflect.TypeOf((*MockInteractor)(nil).ProduceDeploymentStatisticsOfRepo), ctx, r, d)
-}
-
-// SyncDeploymentStatus mocks base method.
-func (m *MockInteractor) SyncDeploymentStatus(ctx context.Context, ds *ent.DeploymentStatus) (*ent.DeploymentStatus, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SyncDeploymentStatus", ctx, ds)
-	ret0, _ := ret[0].(*ent.DeploymentStatus)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SyncDeploymentStatus indicates an expected call of SyncDeploymentStatus.
-func (mr *MockInteractorMockRecorder) SyncDeploymentStatus(ctx, ds interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncDeploymentStatus", reflect.TypeOf((*MockInteractor)(nil).SyncDeploymentStatus), ctx, ds)
 }
 
 // UpdateDeployment mocks base method.

--- a/internal/server/slack/interface.go
+++ b/internal/server/slack/interface.go
@@ -17,6 +17,11 @@ type (
 		UpdateChatUser(ctx context.Context, cu *ent.ChatUser) (*ent.ChatUser, error)
 		DeleteChatUser(ctx context.Context, cu *ent.ChatUser) error
 
+		FindDeploymentByID(ctx context.Context, id int) (*ent.Deployment, error)
+		FindDeploymentStatusByID(ctx context.Context, id int) (*ent.DeploymentStatus, error)
+
+		FindReviewByID(ctx context.Context, id int) (*ent.Review, error)
+
 		SubscribeEvent(fn func(e *ent.Event)) error
 		UnsubscribeEvent(fn func(e *ent.Event)) error
 	}

--- a/internal/server/slack/mock/interactor.go
+++ b/internal/server/slack/mock/interactor.go
@@ -79,6 +79,51 @@ func (mr *MockInteractorMockRecorder) FindChatUserByID(ctx, id interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindChatUserByID", reflect.TypeOf((*MockInteractor)(nil).FindChatUserByID), ctx, id)
 }
 
+// FindDeploymentByID mocks base method.
+func (m *MockInteractor) FindDeploymentByID(ctx context.Context, id int) (*ent.Deployment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindDeploymentByID", ctx, id)
+	ret0, _ := ret[0].(*ent.Deployment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindDeploymentByID indicates an expected call of FindDeploymentByID.
+func (mr *MockInteractorMockRecorder) FindDeploymentByID(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindDeploymentByID", reflect.TypeOf((*MockInteractor)(nil).FindDeploymentByID), ctx, id)
+}
+
+// FindDeploymentStatusByID mocks base method.
+func (m *MockInteractor) FindDeploymentStatusByID(ctx context.Context, id int) (*ent.DeploymentStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindDeploymentStatusByID", ctx, id)
+	ret0, _ := ret[0].(*ent.DeploymentStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindDeploymentStatusByID indicates an expected call of FindDeploymentStatusByID.
+func (mr *MockInteractorMockRecorder) FindDeploymentStatusByID(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindDeploymentStatusByID", reflect.TypeOf((*MockInteractor)(nil).FindDeploymentStatusByID), ctx, id)
+}
+
+// FindReviewByID mocks base method.
+func (m *MockInteractor) FindReviewByID(ctx context.Context, id int) (*ent.Review, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindReviewByID", ctx, id)
+	ret0, _ := ret[0].(*ent.Review)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindReviewByID indicates an expected call of FindReviewByID.
+func (mr *MockInteractorMockRecorder) FindReviewByID(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindReviewByID", reflect.TypeOf((*MockInteractor)(nil).FindReviewByID), ctx, id)
+}
+
 // FindUserByID mocks base method.
 func (m *MockInteractor) FindUserByID(ctx context.Context, id int64) (*ent.User, error) {
 	m.ctrl.T.Helper()

--- a/internal/server/slack/notification.go
+++ b/internal/server/slack/notification.go
@@ -8,16 +8,8 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/gitploy-io/gitploy/model/ent"
-	"github.com/gitploy-io/gitploy/model/ent/deployment"
 	"github.com/gitploy-io/gitploy/model/ent/event"
 	"github.com/gitploy-io/gitploy/model/ent/review"
-)
-
-const (
-	colorGray   = "#bfbfbf"
-	colorPurple = "#722ed1"
-	colorGreen  = "#52c41a"
-	colorRed    = "#f5222d"
 )
 
 func (s *Slack) Notify(ctx context.Context, e *ent.Event) {
@@ -26,123 +18,130 @@ func (s *Slack) Notify(ctx context.Context, e *ent.Event) {
 		return
 	}
 
-	if e.Kind == event.KindDeployment {
-		s.notifyDeploymentEvent(ctx, e)
-	}
+	switch e.Kind {
+	case event.KindDeploymentStatus:
+		ds, err := s.i.FindDeploymentStatusByID(ctx, e.DeploymentStatusID)
+		if err != nil {
+			s.log.Error("Failed to find the deployment status.", zap.Error(err))
+			break
+		}
 
-	if e.Kind == event.KindReview {
-		s.notifyReviewEvent(ctx, e)
+		s.notifyDeploymentStatusEvent(ctx, ds)
+	case event.KindReview:
+		r, err := s.i.FindReviewByID(ctx, e.ReviewID)
+		if err != nil {
+			s.log.Error("Failed to find the review.", zap.Error(err))
+			break
+		}
+
+		s.notifyReviewEvent(ctx, r)
 	}
 }
 
-func (s *Slack) notifyDeploymentEvent(ctx context.Context, e *ent.Event) {
-	var d *ent.Deployment
-
-	if d = e.Edges.Deployment; d == nil {
-		s.log.Error("The eager loading of event has failed.")
-		return
-	}
-
-	if d.Edges.User == nil || d.Edges.Repo == nil {
-		s.log.Error("The eager loading of deployment has failed.")
-		return
-	}
-
-	owner, err := s.i.FindUserByID(ctx, d.Edges.User.ID)
+func (s *Slack) notifyDeploymentStatusEvent(ctx context.Context, ds *ent.DeploymentStatus) {
+	d, err := s.i.FindDeploymentByID(ctx, ds.DeploymentID)
 	if err != nil {
-		s.log.Error("It has failed to find the owner of the deployment.", zap.Error(err))
+		s.log.Error("Failed to find the deployment.", zap.Error(err))
 		return
 	}
-	if owner.Edges.ChatUser == nil {
+
+	owner, err := s.i.FindUserByID(ctx, d.UserID)
+	if err != nil {
+		s.log.Error("Failed to find the owner of the deployment.", zap.Error(err))
+		return
+	} else if owner.Edges.ChatUser == nil {
 		s.log.Debug("Skip the notification. The owner is not connected with Slack.")
 		return
 	}
 
 	// Build the message and post it.
-	var option slack.MsgOption
-
-	if e.Type == event.TypeCreated {
-		option = slack.MsgOptionAttachments(slack.Attachment{
-			Color:   mapDeploymentStatusToColor(d.Status),
-			Pretext: fmt.Sprintf("*New Deployment #%d*", d.Number),
-			Text:    fmt.Sprintf("*%s* deploys `%s` to the `%s` environment of `%s`. <%s|• View Details> ", owner.Login, d.GetShortRef(), d.Env, d.Edges.Repo.GetFullName(), s.buildDeploymentLink(d.Edges.Repo, d)),
-		})
-	} else if e.Type == event.TypeUpdated {
-		option = slack.MsgOptionAttachments(slack.Attachment{
-			Color:   mapDeploymentStatusToColor(d.Status),
-			Pretext: fmt.Sprintf("*Deployment Updated #%d*", d.Number),
-			Text:    fmt.Sprintf("The deployment <%s|#%d> of `%s` is updated `%s`.", s.buildDeploymentLink(d.Edges.Repo, d), d.Number, d.Edges.Repo.GetFullName(), d.Status),
-		})
+	options := []slack.MsgOption{
+		slack.MsgOptionBlocks(
+			slack.NewSectionBlock(
+				slack.NewTextBlockObject(
+					slack.MarkdownType,
+					fmt.Sprintf("*%s* *#%d* %s", d.Edges.Repo.GetFullName(), d.Number, buildLink(s.buildDeploymentLink(d.Edges.Repo, d), " • View Details")),
+					false, false,
+				),
+				[]*slack.TextBlockObject{
+					slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*Status:*\n`%s`", ds.Status), false, false),
+					slack.NewTextBlockObject(
+						slack.MarkdownType,
+						fmt.Sprintf("*Description:*\n>%s %s", ds.Description, buildLink(ds.LogURL, " • View Log")),
+						false, false,
+					),
+				}, nil,
+			),
+		),
 	}
 
-	if _, _, err := slack.
-		New(owner.Edges.ChatUser.BotToken).
-		PostMessageContext(ctx, owner.Edges.ChatUser.ID, option); err != nil {
-		s.log.Error("It has failed to post the message.", zap.Error(err))
+	if _, _, err := slack.New(owner.Edges.ChatUser.BotToken).
+		PostMessageContext(ctx, owner.Edges.ChatUser.ID, options...); err != nil {
+		s.log.Error("Failed to post the message.", zap.Error(err))
 	}
 }
 
-func (s *Slack) notifyReviewEvent(ctx context.Context, e *ent.Event) {
-	var (
-		r *ent.Review
-		d *ent.Deployment
-	)
-
-	if r = e.Edges.Review; r == nil {
-		s.log.Error("The eager loading of review has failed.")
+func (s *Slack) notifyReviewEvent(ctx context.Context, r *ent.Review) {
+	d, err := s.i.FindDeploymentByID(ctx, r.DeploymentID)
+	if err != nil {
+		s.log.Error("Failed to find the deployment.", zap.Error(err))
 		return
 	}
 
-	if d = r.Edges.Deployment; d == nil {
-		s.log.Error("The eager loading of deployment has failed.")
+	deployer := d.Edges.User
+	if deployer == nil {
+		s.log.Error("Failed to find the deployer.", zap.Error(err))
+	}
+
+	reviewer, err := s.i.FindUserByID(ctx, r.UserID)
+	if err != nil {
+		s.log.Error("Failed to find the reviewer.", zap.Error(err))
 		return
 	}
 
-	if e.Type == event.TypeCreated {
-		option := slack.MsgOptionAttachments(slack.Attachment{
-			Color:   colorPurple,
-			Pretext: "*Review Requested*",
-			Text:    fmt.Sprintf("%s requested the review for the deployment <%s|#%d> of `%s`.", d.Edges.User.Login, s.buildDeploymentLink(d.Edges.Repo, d), d.Number, d.Edges.Repo.GetFullName()),
-		})
+	switch r.Status {
+	case review.StatusPending:
+		option := slack.MsgOptionBlocks(
+			slack.NewSectionBlock(
+				slack.NewTextBlockObject(
+					slack.MarkdownType,
+					fmt.Sprintf("%s requested a review in `%s` *#%d* %s", deployer.Login, d.Edges.Repo.GetFullName(), d.Number, buildLink(s.buildDeploymentLink(d.Edges.Repo, d), " • View Details")),
+					false, false,
+				),
+				nil, nil,
+			),
+		)
 
-		recipient, err := s.i.FindUserByID(ctx, r.Edges.User.ID)
-		if err != nil {
-			s.log.Error("It has failed to find the recipient of the review.", zap.Error(err))
-			return
-		}
-		if recipient.Edges.ChatUser == nil {
-			s.log.Debug("Skip the notification. The recipient is not connected with Slack.")
-			return
-		}
-
-		if _, _, err := slack.
-			New(recipient.Edges.ChatUser.BotToken).
-			PostMessageContext(ctx, recipient.Edges.ChatUser.ID, option); err != nil {
-			s.log.Error("It has failed to post the message.", zap.Error(err))
-		}
-	}
-
-	if e.Type == event.TypeUpdated {
-		option := slack.MsgOptionAttachments(slack.Attachment{
-			Color:   mapReviewStatusToColor(r.Status),
-			Pretext: "*Review Responded*",
-			Text:    fmt.Sprintf("%s *%s* the deployment <%s|#%d> of `%s`.", r.Edges.User.Login, r.Status, s.buildDeploymentLink(d.Edges.Repo, d), d.Number, d.Edges.Repo.GetFullName()),
-		})
-
-		requester, err := s.i.FindUserByID(ctx, d.Edges.User.ID)
-		if err != nil {
-			s.log.Error("It has failed to find the requester of the review.", zap.Error(err))
-			return
-		}
-		if requester.Edges.ChatUser == nil {
-			s.log.Debug("Skip the notification. The requester is not connected with Slack.")
+		if reviewer.Edges.ChatUser == nil {
+			s.log.Debug("Skip the notification. The reviewer is not connected with Slack.")
 			return
 		}
 
-		if _, _, err := slack.
-			New(requester.Edges.ChatUser.BotToken).
-			PostMessageContext(ctx, requester.Edges.ChatUser.ID, option); err != nil {
-			s.log.Error("It has failed to post the message.", zap.Error(err))
+		if _, _, err := slack.New(reviewer.Edges.ChatUser.BotToken).
+			PostMessageContext(ctx, reviewer.Edges.ChatUser.ID, option); err != nil {
+			s.log.Error("Failed to post the message.", zap.Error(err))
+		}
+
+	default:
+		option := slack.MsgOptionBlocks(
+			slack.NewSectionBlock(
+				slack.NewTextBlockObject(
+					slack.MarkdownType,
+					fmt.Sprintf("%s %s in `%s` *#%d* %s", reviewer.Login, r.Status, d.Edges.Repo.GetFullName(), d.Number, buildLink(s.buildDeploymentLink(d.Edges.Repo, d), " • View Details")),
+					false, false,
+				),
+				nil, nil,
+			),
+		)
+
+		if deployer.Edges.ChatUser == nil {
+			s.log.Debug("Skip the notification. The deployer is not connected with Slack.")
+			return
+		}
+
+		if _, _, err := slack.New(deployer.Edges.ChatUser.BotToken).
+			PostMessageContext(ctx, deployer.Edges.ChatUser.ID, option); err != nil {
+			s.log.Error("Failed to post the message.", zap.Error(err))
 		}
 	}
 }
@@ -151,34 +150,10 @@ func (s *Slack) buildDeploymentLink(r *ent.Repo, d *ent.Deployment) string {
 	return fmt.Sprintf("%s://%s/%s/deployments/%d", s.proto, s.host, r.GetFullName(), d.Number)
 }
 
-func mapDeploymentStatusToColor(status deployment.Status) string {
-	switch status {
-	case deployment.StatusWaiting:
-		return colorGray
-	case deployment.StatusCreated:
-		return colorPurple
-	case deployment.StatusQueued:
-		return colorPurple
-	case deployment.StatusRunning:
-		return colorPurple
-	case deployment.StatusSuccess:
-		return colorGreen
-	case deployment.StatusFailure:
-		return colorRed
-	default:
-		return colorGray
+func buildLink(link string, msg string) string {
+	if msg == "" || link == "" {
+		return ""
 	}
-}
 
-func mapReviewStatusToColor(status review.Status) string {
-	switch status {
-	case review.StatusPending:
-		return colorGray
-	case review.StatusApproved:
-		return colorGreen
-	case review.StatusRejected:
-		return colorRed
-	default:
-		return colorGray
-	}
+	return fmt.Sprintf("<%s|%s>", link, msg)
 }

--- a/model/ent/client.go
+++ b/model/ent/client.go
@@ -448,22 +448,6 @@ func (c *DeploymentClient) QueryDeploymentStatuses(d *Deployment) *DeploymentSta
 	return query
 }
 
-// QueryEvent queries the event edge of a Deployment.
-func (c *DeploymentClient) QueryEvent(d *Deployment) *EventQuery {
-	query := &EventQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
-		id := d.ID
-		step := sqlgraph.NewStep(
-			sqlgraph.From(deployment.Table, deployment.FieldID, id),
-			sqlgraph.To(event.Table, event.FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, deployment.EventTable, deployment.EventColumn),
-		)
-		fromV = sqlgraph.Neighbors(d.driver.Dialect(), step)
-		return fromV, nil
-	}
-	return query
-}
-
 // Hooks returns the client hooks.
 func (c *DeploymentClient) Hooks() []Hook {
 	return c.hooks.Deployment
@@ -796,22 +780,6 @@ func (c *EventClient) GetX(ctx context.Context, id int) *Event {
 		panic(err)
 	}
 	return obj
-}
-
-// QueryDeployment queries the deployment edge of a Event.
-func (c *EventClient) QueryDeployment(e *Event) *DeploymentQuery {
-	query := &DeploymentQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
-		id := e.ID
-		step := sqlgraph.NewStep(
-			sqlgraph.From(event.Table, event.FieldID, id),
-			sqlgraph.To(deployment.Table, deployment.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, event.DeploymentTable, event.DeploymentColumn),
-		)
-		fromV = sqlgraph.Neighbors(e.driver.Dialect(), step)
-		return fromV, nil
-	}
-	return query
 }
 
 // QueryDeploymentStatus queries the deployment_status edge of a Event.

--- a/model/ent/deployment.go
+++ b/model/ent/deployment.go
@@ -68,11 +68,9 @@ type DeploymentEdges struct {
 	Reviews []*Review `json:"reviews,omitempty"`
 	// DeploymentStatuses holds the value of the deployment_statuses edge.
 	DeploymentStatuses []*DeploymentStatus `json:"deployment_statuses,omitempty"`
-	// Event holds the value of the event edge.
-	Event []*Event `json:"event,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [5]bool
+	loadedTypes [4]bool
 }
 
 // UserOrErr returns the User value or an error if the edge
@@ -119,15 +117,6 @@ func (e DeploymentEdges) DeploymentStatusesOrErr() ([]*DeploymentStatus, error) 
 		return e.DeploymentStatuses, nil
 	}
 	return nil, &NotLoadedError{edge: "deployment_statuses"}
-}
-
-// EventOrErr returns the Event value or an error if the edge
-// was not loaded in eager-loading.
-func (e DeploymentEdges) EventOrErr() ([]*Event, error) {
-	if e.loadedTypes[4] {
-		return e.Event, nil
-	}
-	return nil, &NotLoadedError{edge: "event"}
 }
 
 // scanValues returns the types for scanning values from sql.Rows.
@@ -295,11 +284,6 @@ func (d *Deployment) QueryReviews() *ReviewQuery {
 // QueryDeploymentStatuses queries the "deployment_statuses" edge of the Deployment entity.
 func (d *Deployment) QueryDeploymentStatuses() *DeploymentStatusQuery {
 	return (&DeploymentClient{config: d.config}).QueryDeploymentStatuses(d)
-}
-
-// QueryEvent queries the "event" edge of the Deployment entity.
-func (d *Deployment) QueryEvent() *EventQuery {
-	return (&DeploymentClient{config: d.config}).QueryEvent(d)
 }
 
 // Update returns a builder for updating this Deployment.

--- a/model/ent/deployment/deployment.go
+++ b/model/ent/deployment/deployment.go
@@ -54,8 +54,6 @@ const (
 	EdgeReviews = "reviews"
 	// EdgeDeploymentStatuses holds the string denoting the deployment_statuses edge name in mutations.
 	EdgeDeploymentStatuses = "deployment_statuses"
-	// EdgeEvent holds the string denoting the event edge name in mutations.
-	EdgeEvent = "event"
 	// Table holds the table name of the deployment in the database.
 	Table = "deployments"
 	// UserTable is the table that holds the user relation/edge.
@@ -86,13 +84,6 @@ const (
 	DeploymentStatusesInverseTable = "deployment_status"
 	// DeploymentStatusesColumn is the table column denoting the deployment_statuses relation/edge.
 	DeploymentStatusesColumn = "deployment_id"
-	// EventTable is the table that holds the event relation/edge.
-	EventTable = "events"
-	// EventInverseTable is the table name for the Event entity.
-	// It exists in this package in order to avoid circular dependency with the "event" package.
-	EventInverseTable = "events"
-	// EventColumn is the table column denoting the event relation/edge.
-	EventColumn = "deployment_id"
 )
 
 // Columns holds all SQL columns for deployment fields.

--- a/model/ent/deployment/where.go
+++ b/model/ent/deployment/where.go
@@ -1445,34 +1445,6 @@ func HasDeploymentStatusesWith(preds ...predicate.DeploymentStatus) predicate.De
 	})
 }
 
-// HasEvent applies the HasEdge predicate on the "event" edge.
-func HasEvent() predicate.Deployment {
-	return predicate.Deployment(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(EventTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, EventTable, EventColumn),
-		)
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasEventWith applies the HasEdge predicate on the "event" edge with a given conditions (other predicates).
-func HasEventWith(preds ...predicate.Event) predicate.Deployment {
-	return predicate.Deployment(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(EventInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, EventTable, EventColumn),
-		)
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
-}
-
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Deployment) predicate.Deployment {
 	return predicate.Deployment(func(s *sql.Selector) {

--- a/model/ent/deployment_create.go
+++ b/model/ent/deployment_create.go
@@ -12,7 +12,6 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/gitploy-io/gitploy/model/ent/deployment"
 	"github.com/gitploy-io/gitploy/model/ent/deploymentstatus"
-	"github.com/gitploy-io/gitploy/model/ent/event"
 	"github.com/gitploy-io/gitploy/model/ent/repo"
 	"github.com/gitploy-io/gitploy/model/ent/review"
 	"github.com/gitploy-io/gitploy/model/ent/user"
@@ -253,21 +252,6 @@ func (dc *DeploymentCreate) AddDeploymentStatuses(d ...*DeploymentStatus) *Deplo
 		ids[i] = d[i].ID
 	}
 	return dc.AddDeploymentStatusIDs(ids...)
-}
-
-// AddEventIDs adds the "event" edge to the Event entity by IDs.
-func (dc *DeploymentCreate) AddEventIDs(ids ...int) *DeploymentCreate {
-	dc.mutation.AddEventIDs(ids...)
-	return dc
-}
-
-// AddEvent adds the "event" edges to the Event entity.
-func (dc *DeploymentCreate) AddEvent(e ...*Event) *DeploymentCreate {
-	ids := make([]int, len(e))
-	for i := range e {
-		ids[i] = e[i].ID
-	}
-	return dc.AddEventIDs(ids...)
 }
 
 // Mutation returns the DeploymentMutation object of the builder.
@@ -640,25 +624,6 @@ func (dc *DeploymentCreate) createSpec() (*Deployment, *sqlgraph.CreateSpec) {
 				IDSpec: &sqlgraph.FieldSpec{
 					Type:   field.TypeInt,
 					Column: deploymentstatus.FieldID,
-				},
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges = append(_spec.Edges, edge)
-	}
-	if nodes := dc.mutation.EventIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
-			Inverse: false,
-			Table:   deployment.EventTable,
-			Columns: []string{deployment.EventColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: &sqlgraph.FieldSpec{
-					Type:   field.TypeInt,
-					Column: event.FieldID,
 				},
 			},
 		}

--- a/model/ent/deployment_update.go
+++ b/model/ent/deployment_update.go
@@ -13,7 +13,6 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/gitploy-io/gitploy/model/ent/deployment"
 	"github.com/gitploy-io/gitploy/model/ent/deploymentstatus"
-	"github.com/gitploy-io/gitploy/model/ent/event"
 	"github.com/gitploy-io/gitploy/model/ent/predicate"
 	"github.com/gitploy-io/gitploy/model/ent/repo"
 	"github.com/gitploy-io/gitploy/model/ent/review"
@@ -312,21 +311,6 @@ func (du *DeploymentUpdate) AddDeploymentStatuses(d ...*DeploymentStatus) *Deplo
 	return du.AddDeploymentStatusIDs(ids...)
 }
 
-// AddEventIDs adds the "event" edge to the Event entity by IDs.
-func (du *DeploymentUpdate) AddEventIDs(ids ...int) *DeploymentUpdate {
-	du.mutation.AddEventIDs(ids...)
-	return du
-}
-
-// AddEvent adds the "event" edges to the Event entity.
-func (du *DeploymentUpdate) AddEvent(e ...*Event) *DeploymentUpdate {
-	ids := make([]int, len(e))
-	for i := range e {
-		ids[i] = e[i].ID
-	}
-	return du.AddEventIDs(ids...)
-}
-
 // Mutation returns the DeploymentMutation object of the builder.
 func (du *DeploymentUpdate) Mutation() *DeploymentMutation {
 	return du.mutation
@@ -384,27 +368,6 @@ func (du *DeploymentUpdate) RemoveDeploymentStatuses(d ...*DeploymentStatus) *De
 		ids[i] = d[i].ID
 	}
 	return du.RemoveDeploymentStatusIDs(ids...)
-}
-
-// ClearEvent clears all "event" edges to the Event entity.
-func (du *DeploymentUpdate) ClearEvent() *DeploymentUpdate {
-	du.mutation.ClearEvent()
-	return du
-}
-
-// RemoveEventIDs removes the "event" edge to Event entities by IDs.
-func (du *DeploymentUpdate) RemoveEventIDs(ids ...int) *DeploymentUpdate {
-	du.mutation.RemoveEventIDs(ids...)
-	return du
-}
-
-// RemoveEvent removes "event" edges to Event entities.
-func (du *DeploymentUpdate) RemoveEvent(e ...*Event) *DeploymentUpdate {
-	ids := make([]int, len(e))
-	for i := range e {
-		ids[i] = e[i].ID
-	}
-	return du.RemoveEventIDs(ids...)
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
@@ -860,60 +823,6 @@ func (du *DeploymentUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
-	if du.mutation.EventCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
-			Inverse: false,
-			Table:   deployment.EventTable,
-			Columns: []string{deployment.EventColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: &sqlgraph.FieldSpec{
-					Type:   field.TypeInt,
-					Column: event.FieldID,
-				},
-			},
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := du.mutation.RemovedEventIDs(); len(nodes) > 0 && !du.mutation.EventCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
-			Inverse: false,
-			Table:   deployment.EventTable,
-			Columns: []string{deployment.EventColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: &sqlgraph.FieldSpec{
-					Type:   field.TypeInt,
-					Column: event.FieldID,
-				},
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := du.mutation.EventIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
-			Inverse: false,
-			Table:   deployment.EventTable,
-			Columns: []string{deployment.EventColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: &sqlgraph.FieldSpec{
-					Type:   field.TypeInt,
-					Column: event.FieldID,
-				},
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
 	if n, err = sqlgraph.UpdateNodes(ctx, du.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{deployment.Label}
@@ -1212,21 +1121,6 @@ func (duo *DeploymentUpdateOne) AddDeploymentStatuses(d ...*DeploymentStatus) *D
 	return duo.AddDeploymentStatusIDs(ids...)
 }
 
-// AddEventIDs adds the "event" edge to the Event entity by IDs.
-func (duo *DeploymentUpdateOne) AddEventIDs(ids ...int) *DeploymentUpdateOne {
-	duo.mutation.AddEventIDs(ids...)
-	return duo
-}
-
-// AddEvent adds the "event" edges to the Event entity.
-func (duo *DeploymentUpdateOne) AddEvent(e ...*Event) *DeploymentUpdateOne {
-	ids := make([]int, len(e))
-	for i := range e {
-		ids[i] = e[i].ID
-	}
-	return duo.AddEventIDs(ids...)
-}
-
 // Mutation returns the DeploymentMutation object of the builder.
 func (duo *DeploymentUpdateOne) Mutation() *DeploymentMutation {
 	return duo.mutation
@@ -1284,27 +1178,6 @@ func (duo *DeploymentUpdateOne) RemoveDeploymentStatuses(d ...*DeploymentStatus)
 		ids[i] = d[i].ID
 	}
 	return duo.RemoveDeploymentStatusIDs(ids...)
-}
-
-// ClearEvent clears all "event" edges to the Event entity.
-func (duo *DeploymentUpdateOne) ClearEvent() *DeploymentUpdateOne {
-	duo.mutation.ClearEvent()
-	return duo
-}
-
-// RemoveEventIDs removes the "event" edge to Event entities by IDs.
-func (duo *DeploymentUpdateOne) RemoveEventIDs(ids ...int) *DeploymentUpdateOne {
-	duo.mutation.RemoveEventIDs(ids...)
-	return duo
-}
-
-// RemoveEvent removes "event" edges to Event entities.
-func (duo *DeploymentUpdateOne) RemoveEvent(e ...*Event) *DeploymentUpdateOne {
-	ids := make([]int, len(e))
-	for i := range e {
-		ids[i] = e[i].ID
-	}
-	return duo.RemoveEventIDs(ids...)
 }
 
 // Select allows selecting one or more fields (columns) of the returned entity.
@@ -1776,60 +1649,6 @@ func (duo *DeploymentUpdateOne) sqlSave(ctx context.Context) (_node *Deployment,
 				IDSpec: &sqlgraph.FieldSpec{
 					Type:   field.TypeInt,
 					Column: deploymentstatus.FieldID,
-				},
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
-	if duo.mutation.EventCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
-			Inverse: false,
-			Table:   deployment.EventTable,
-			Columns: []string{deployment.EventColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: &sqlgraph.FieldSpec{
-					Type:   field.TypeInt,
-					Column: event.FieldID,
-				},
-			},
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := duo.mutation.RemovedEventIDs(); len(nodes) > 0 && !duo.mutation.EventCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
-			Inverse: false,
-			Table:   deployment.EventTable,
-			Columns: []string{deployment.EventColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: &sqlgraph.FieldSpec{
-					Type:   field.TypeInt,
-					Column: event.FieldID,
-				},
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := duo.mutation.EventIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
-			Inverse: false,
-			Table:   deployment.EventTable,
-			Columns: []string{deployment.EventColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: &sqlgraph.FieldSpec{
-					Type:   field.TypeInt,
-					Column: event.FieldID,
 				},
 			},
 		}

--- a/model/ent/deploymentstatus.go
+++ b/model/ent/deploymentstatus.go
@@ -38,9 +38,11 @@ type DeploymentStatus struct {
 type DeploymentStatusEdges struct {
 	// Deployment holds the value of the deployment edge.
 	Deployment *Deployment `json:"deployment,omitempty"`
+	// Event holds the value of the event edge.
+	Event []*Event `json:"event,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [1]bool
+	loadedTypes [2]bool
 }
 
 // DeploymentOrErr returns the Deployment value or an error if the edge
@@ -55,6 +57,15 @@ func (e DeploymentStatusEdges) DeploymentOrErr() (*Deployment, error) {
 		return e.Deployment, nil
 	}
 	return nil, &NotLoadedError{edge: "deployment"}
+}
+
+// EventOrErr returns the Event value or an error if the edge
+// was not loaded in eager-loading.
+func (e DeploymentStatusEdges) EventOrErr() ([]*Event, error) {
+	if e.loadedTypes[1] {
+		return e.Event, nil
+	}
+	return nil, &NotLoadedError{edge: "event"}
 }
 
 // scanValues returns the types for scanning values from sql.Rows.
@@ -133,6 +144,11 @@ func (ds *DeploymentStatus) assignValues(columns []string, values []interface{})
 // QueryDeployment queries the "deployment" edge of the DeploymentStatus entity.
 func (ds *DeploymentStatus) QueryDeployment() *DeploymentQuery {
 	return (&DeploymentStatusClient{config: ds.config}).QueryDeployment(ds)
+}
+
+// QueryEvent queries the "event" edge of the DeploymentStatus entity.
+func (ds *DeploymentStatus) QueryEvent() *EventQuery {
+	return (&DeploymentStatusClient{config: ds.config}).QueryEvent(ds)
 }
 
 // Update returns a builder for updating this DeploymentStatus.

--- a/model/ent/deploymentstatus.go
+++ b/model/ent/deploymentstatus.go
@@ -31,7 +31,7 @@ type DeploymentStatus struct {
 	// DeploymentID holds the value of the "deployment_id" field.
 	DeploymentID int `json:"deployment_id"`
 	// RepoID holds the value of the "repo_id" field.
-	RepoID int64 `json:"repo_id"`
+	RepoID int64 `json:"repo_id,omitemtpy"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the DeploymentStatusQuery when eager-loading is set.
 	Edges DeploymentStatusEdges `json:"edges"`

--- a/model/ent/deploymentstatus.go
+++ b/model/ent/deploymentstatus.go
@@ -10,6 +10,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"github.com/gitploy-io/gitploy/model/ent/deployment"
 	"github.com/gitploy-io/gitploy/model/ent/deploymentstatus"
+	"github.com/gitploy-io/gitploy/model/ent/repo"
 )
 
 // DeploymentStatus is the model entity for the DeploymentStatus schema.
@@ -29,6 +30,8 @@ type DeploymentStatus struct {
 	UpdatedAt time.Time `json:"updated_at"`
 	// DeploymentID holds the value of the "deployment_id" field.
 	DeploymentID int `json:"deployment_id"`
+	// RepoID holds the value of the "repo_id" field.
+	RepoID int64 `json:"repo_id"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the DeploymentStatusQuery when eager-loading is set.
 	Edges DeploymentStatusEdges `json:"edges"`
@@ -38,11 +41,13 @@ type DeploymentStatus struct {
 type DeploymentStatusEdges struct {
 	// Deployment holds the value of the deployment edge.
 	Deployment *Deployment `json:"deployment,omitempty"`
+	// Repo holds the value of the repo edge.
+	Repo *Repo `json:"repo,omitempty"`
 	// Event holds the value of the event edge.
 	Event []*Event `json:"event,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [2]bool
+	loadedTypes [3]bool
 }
 
 // DeploymentOrErr returns the Deployment value or an error if the edge
@@ -59,10 +64,24 @@ func (e DeploymentStatusEdges) DeploymentOrErr() (*Deployment, error) {
 	return nil, &NotLoadedError{edge: "deployment"}
 }
 
+// RepoOrErr returns the Repo value or an error if the edge
+// was not loaded in eager-loading, or loaded but was not found.
+func (e DeploymentStatusEdges) RepoOrErr() (*Repo, error) {
+	if e.loadedTypes[1] {
+		if e.Repo == nil {
+			// The edge repo was loaded in eager-loading,
+			// but was not found.
+			return nil, &NotFoundError{label: repo.Label}
+		}
+		return e.Repo, nil
+	}
+	return nil, &NotLoadedError{edge: "repo"}
+}
+
 // EventOrErr returns the Event value or an error if the edge
 // was not loaded in eager-loading.
 func (e DeploymentStatusEdges) EventOrErr() ([]*Event, error) {
-	if e.loadedTypes[1] {
+	if e.loadedTypes[2] {
 		return e.Event, nil
 	}
 	return nil, &NotLoadedError{edge: "event"}
@@ -73,7 +92,7 @@ func (*DeploymentStatus) scanValues(columns []string) ([]interface{}, error) {
 	values := make([]interface{}, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case deploymentstatus.FieldID, deploymentstatus.FieldDeploymentID:
+		case deploymentstatus.FieldID, deploymentstatus.FieldDeploymentID, deploymentstatus.FieldRepoID:
 			values[i] = new(sql.NullInt64)
 		case deploymentstatus.FieldStatus, deploymentstatus.FieldDescription, deploymentstatus.FieldLogURL:
 			values[i] = new(sql.NullString)
@@ -136,6 +155,12 @@ func (ds *DeploymentStatus) assignValues(columns []string, values []interface{})
 			} else if value.Valid {
 				ds.DeploymentID = int(value.Int64)
 			}
+		case deploymentstatus.FieldRepoID:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field repo_id", values[i])
+			} else if value.Valid {
+				ds.RepoID = value.Int64
+			}
 		}
 	}
 	return nil
@@ -144,6 +169,11 @@ func (ds *DeploymentStatus) assignValues(columns []string, values []interface{})
 // QueryDeployment queries the "deployment" edge of the DeploymentStatus entity.
 func (ds *DeploymentStatus) QueryDeployment() *DeploymentQuery {
 	return (&DeploymentStatusClient{config: ds.config}).QueryDeployment(ds)
+}
+
+// QueryRepo queries the "repo" edge of the DeploymentStatus entity.
+func (ds *DeploymentStatus) QueryRepo() *RepoQuery {
+	return (&DeploymentStatusClient{config: ds.config}).QueryRepo(ds)
 }
 
 // QueryEvent queries the "event" edge of the DeploymentStatus entity.
@@ -186,6 +216,8 @@ func (ds *DeploymentStatus) String() string {
 	builder.WriteString(ds.UpdatedAt.Format(time.ANSIC))
 	builder.WriteString(", deployment_id=")
 	builder.WriteString(fmt.Sprintf("%v", ds.DeploymentID))
+	builder.WriteString(", repo_id=")
+	builder.WriteString(fmt.Sprintf("%v", ds.RepoID))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/model/ent/deploymentstatus/deploymentstatus.go
+++ b/model/ent/deploymentstatus/deploymentstatus.go
@@ -25,6 +25,8 @@ const (
 	FieldDeploymentID = "deployment_id"
 	// EdgeDeployment holds the string denoting the deployment edge name in mutations.
 	EdgeDeployment = "deployment"
+	// EdgeEvent holds the string denoting the event edge name in mutations.
+	EdgeEvent = "event"
 	// Table holds the table name of the deploymentstatus in the database.
 	Table = "deployment_status"
 	// DeploymentTable is the table that holds the deployment relation/edge.
@@ -34,6 +36,13 @@ const (
 	DeploymentInverseTable = "deployments"
 	// DeploymentColumn is the table column denoting the deployment relation/edge.
 	DeploymentColumn = "deployment_id"
+	// EventTable is the table that holds the event relation/edge.
+	EventTable = "events"
+	// EventInverseTable is the table name for the Event entity.
+	// It exists in this package in order to avoid circular dependency with the "event" package.
+	EventInverseTable = "events"
+	// EventColumn is the table column denoting the event relation/edge.
+	EventColumn = "deployment_status_id"
 )
 
 // Columns holds all SQL columns for deploymentstatus fields.

--- a/model/ent/deploymentstatus/deploymentstatus.go
+++ b/model/ent/deploymentstatus/deploymentstatus.go
@@ -23,8 +23,12 @@ const (
 	FieldUpdatedAt = "updated_at"
 	// FieldDeploymentID holds the string denoting the deployment_id field in the database.
 	FieldDeploymentID = "deployment_id"
+	// FieldRepoID holds the string denoting the repo_id field in the database.
+	FieldRepoID = "repo_id"
 	// EdgeDeployment holds the string denoting the deployment edge name in mutations.
 	EdgeDeployment = "deployment"
+	// EdgeRepo holds the string denoting the repo edge name in mutations.
+	EdgeRepo = "repo"
 	// EdgeEvent holds the string denoting the event edge name in mutations.
 	EdgeEvent = "event"
 	// Table holds the table name of the deploymentstatus in the database.
@@ -36,6 +40,13 @@ const (
 	DeploymentInverseTable = "deployments"
 	// DeploymentColumn is the table column denoting the deployment relation/edge.
 	DeploymentColumn = "deployment_id"
+	// RepoTable is the table that holds the repo relation/edge.
+	RepoTable = "deployment_status"
+	// RepoInverseTable is the table name for the Repo entity.
+	// It exists in this package in order to avoid circular dependency with the "repo" package.
+	RepoInverseTable = "repos"
+	// RepoColumn is the table column denoting the repo relation/edge.
+	RepoColumn = "repo_id"
 	// EventTable is the table that holds the event relation/edge.
 	EventTable = "events"
 	// EventInverseTable is the table name for the Event entity.
@@ -54,6 +65,7 @@ var Columns = []string{
 	FieldCreatedAt,
 	FieldUpdatedAt,
 	FieldDeploymentID,
+	FieldRepoID,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).

--- a/model/ent/deploymentstatus/where.go
+++ b/model/ent/deploymentstatus/where.go
@@ -135,6 +135,13 @@ func DeploymentID(v int) predicate.DeploymentStatus {
 	})
 }
 
+// RepoID applies equality check predicate on the "repo_id" field. It's identical to RepoIDEQ.
+func RepoID(v int64) predicate.DeploymentStatus {
+	return predicate.DeploymentStatus(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldRepoID), v))
+	})
+}
+
 // StatusEQ applies the EQ predicate on the "status" field.
 func StatusEQ(v string) predicate.DeploymentStatus {
 	return predicate.DeploymentStatus(func(s *sql.Selector) {
@@ -696,6 +703,54 @@ func DeploymentIDNotIn(vs ...int) predicate.DeploymentStatus {
 	})
 }
 
+// RepoIDEQ applies the EQ predicate on the "repo_id" field.
+func RepoIDEQ(v int64) predicate.DeploymentStatus {
+	return predicate.DeploymentStatus(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldRepoID), v))
+	})
+}
+
+// RepoIDNEQ applies the NEQ predicate on the "repo_id" field.
+func RepoIDNEQ(v int64) predicate.DeploymentStatus {
+	return predicate.DeploymentStatus(func(s *sql.Selector) {
+		s.Where(sql.NEQ(s.C(FieldRepoID), v))
+	})
+}
+
+// RepoIDIn applies the In predicate on the "repo_id" field.
+func RepoIDIn(vs ...int64) predicate.DeploymentStatus {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.DeploymentStatus(func(s *sql.Selector) {
+		// if not arguments were provided, append the FALSE constants,
+		// since we can't apply "IN ()". This will make this predicate falsy.
+		if len(v) == 0 {
+			s.Where(sql.False())
+			return
+		}
+		s.Where(sql.In(s.C(FieldRepoID), v...))
+	})
+}
+
+// RepoIDNotIn applies the NotIn predicate on the "repo_id" field.
+func RepoIDNotIn(vs ...int64) predicate.DeploymentStatus {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.DeploymentStatus(func(s *sql.Selector) {
+		// if not arguments were provided, append the FALSE constants,
+		// since we can't apply "IN ()". This will make this predicate falsy.
+		if len(v) == 0 {
+			s.Where(sql.False())
+			return
+		}
+		s.Where(sql.NotIn(s.C(FieldRepoID), v...))
+	})
+}
+
 // HasDeployment applies the HasEdge predicate on the "deployment" edge.
 func HasDeployment() predicate.DeploymentStatus {
 	return predicate.DeploymentStatus(func(s *sql.Selector) {
@@ -715,6 +770,34 @@ func HasDeploymentWith(preds ...predicate.Deployment) predicate.DeploymentStatus
 			sqlgraph.From(Table, FieldID),
 			sqlgraph.To(DeploymentInverseTable, FieldID),
 			sqlgraph.Edge(sqlgraph.M2O, true, DeploymentTable, DeploymentColumn),
+		)
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasRepo applies the HasEdge predicate on the "repo" edge.
+func HasRepo() predicate.DeploymentStatus {
+	return predicate.DeploymentStatus(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.To(RepoTable, FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, RepoTable, RepoColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasRepoWith applies the HasEdge predicate on the "repo" edge with a given conditions (other predicates).
+func HasRepoWith(preds ...predicate.Repo) predicate.DeploymentStatus {
+	return predicate.DeploymentStatus(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.To(RepoInverseTable, FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, RepoTable, RepoColumn),
 		)
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {

--- a/model/ent/deploymentstatus/where.go
+++ b/model/ent/deploymentstatus/where.go
@@ -724,6 +724,34 @@ func HasDeploymentWith(preds ...predicate.Deployment) predicate.DeploymentStatus
 	})
 }
 
+// HasEvent applies the HasEdge predicate on the "event" edge.
+func HasEvent() predicate.DeploymentStatus {
+	return predicate.DeploymentStatus(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.To(EventTable, FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, EventTable, EventColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasEventWith applies the HasEdge predicate on the "event" edge with a given conditions (other predicates).
+func HasEventWith(preds ...predicate.Event) predicate.DeploymentStatus {
+	return predicate.DeploymentStatus(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.To(EventInverseTable, FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, EventTable, EventColumn),
+		)
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.DeploymentStatus) predicate.DeploymentStatus {
 	return predicate.DeploymentStatus(func(s *sql.Selector) {

--- a/model/ent/deploymentstatus/where.go
+++ b/model/ent/deploymentstatus/where.go
@@ -751,6 +751,20 @@ func RepoIDNotIn(vs ...int64) predicate.DeploymentStatus {
 	})
 }
 
+// RepoIDIsNil applies the IsNil predicate on the "repo_id" field.
+func RepoIDIsNil() predicate.DeploymentStatus {
+	return predicate.DeploymentStatus(func(s *sql.Selector) {
+		s.Where(sql.IsNull(s.C(FieldRepoID)))
+	})
+}
+
+// RepoIDNotNil applies the NotNil predicate on the "repo_id" field.
+func RepoIDNotNil() predicate.DeploymentStatus {
+	return predicate.DeploymentStatus(func(s *sql.Selector) {
+		s.Where(sql.NotNull(s.C(FieldRepoID)))
+	})
+}
+
 // HasDeployment applies the HasEdge predicate on the "deployment" edge.
 func HasDeployment() predicate.DeploymentStatus {
 	return predicate.DeploymentStatus(func(s *sql.Selector) {

--- a/model/ent/deploymentstatus_create.go
+++ b/model/ent/deploymentstatus_create.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gitploy-io/gitploy/model/ent/deployment"
 	"github.com/gitploy-io/gitploy/model/ent/deploymentstatus"
 	"github.com/gitploy-io/gitploy/model/ent/event"
+	"github.com/gitploy-io/gitploy/model/ent/repo"
 )
 
 // DeploymentStatusCreate is the builder for creating a DeploymentStatus entity.
@@ -90,9 +91,20 @@ func (dsc *DeploymentStatusCreate) SetDeploymentID(i int) *DeploymentStatusCreat
 	return dsc
 }
 
+// SetRepoID sets the "repo_id" field.
+func (dsc *DeploymentStatusCreate) SetRepoID(i int64) *DeploymentStatusCreate {
+	dsc.mutation.SetRepoID(i)
+	return dsc
+}
+
 // SetDeployment sets the "deployment" edge to the Deployment entity.
 func (dsc *DeploymentStatusCreate) SetDeployment(d *Deployment) *DeploymentStatusCreate {
 	return dsc.SetDeploymentID(d.ID)
+}
+
+// SetRepo sets the "repo" edge to the Repo entity.
+func (dsc *DeploymentStatusCreate) SetRepo(r *Repo) *DeploymentStatusCreate {
+	return dsc.SetRepoID(r.ID)
 }
 
 // AddEventIDs adds the "event" edge to the Event entity by IDs.
@@ -205,8 +217,14 @@ func (dsc *DeploymentStatusCreate) check() error {
 	if _, ok := dsc.mutation.DeploymentID(); !ok {
 		return &ValidationError{Name: "deployment_id", err: errors.New(`ent: missing required field "DeploymentStatus.deployment_id"`)}
 	}
+	if _, ok := dsc.mutation.RepoID(); !ok {
+		return &ValidationError{Name: "repo_id", err: errors.New(`ent: missing required field "DeploymentStatus.repo_id"`)}
+	}
 	if _, ok := dsc.mutation.DeploymentID(); !ok {
 		return &ValidationError{Name: "deployment", err: errors.New(`ent: missing required edge "DeploymentStatus.deployment"`)}
+	}
+	if _, ok := dsc.mutation.RepoID(); !ok {
+		return &ValidationError{Name: "repo", err: errors.New(`ent: missing required edge "DeploymentStatus.repo"`)}
 	}
 	return nil
 }
@@ -293,6 +311,26 @@ func (dsc *DeploymentStatusCreate) createSpec() (*DeploymentStatus, *sqlgraph.Cr
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
 		_node.DeploymentID = nodes[0]
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := dsc.mutation.RepoIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   deploymentstatus.RepoTable,
+			Columns: []string{deploymentstatus.RepoColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt64,
+					Column: repo.FieldID,
+				},
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_node.RepoID = nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := dsc.mutation.EventIDs(); len(nodes) > 0 {

--- a/model/ent/deploymentstatus_create.go
+++ b/model/ent/deploymentstatus_create.go
@@ -97,6 +97,14 @@ func (dsc *DeploymentStatusCreate) SetRepoID(i int64) *DeploymentStatusCreate {
 	return dsc
 }
 
+// SetNillableRepoID sets the "repo_id" field if the given value is not nil.
+func (dsc *DeploymentStatusCreate) SetNillableRepoID(i *int64) *DeploymentStatusCreate {
+	if i != nil {
+		dsc.SetRepoID(*i)
+	}
+	return dsc
+}
+
 // SetDeployment sets the "deployment" edge to the Deployment entity.
 func (dsc *DeploymentStatusCreate) SetDeployment(d *Deployment) *DeploymentStatusCreate {
 	return dsc.SetDeploymentID(d.ID)
@@ -217,14 +225,8 @@ func (dsc *DeploymentStatusCreate) check() error {
 	if _, ok := dsc.mutation.DeploymentID(); !ok {
 		return &ValidationError{Name: "deployment_id", err: errors.New(`ent: missing required field "DeploymentStatus.deployment_id"`)}
 	}
-	if _, ok := dsc.mutation.RepoID(); !ok {
-		return &ValidationError{Name: "repo_id", err: errors.New(`ent: missing required field "DeploymentStatus.repo_id"`)}
-	}
 	if _, ok := dsc.mutation.DeploymentID(); !ok {
 		return &ValidationError{Name: "deployment", err: errors.New(`ent: missing required edge "DeploymentStatus.deployment"`)}
-	}
-	if _, ok := dsc.mutation.RepoID(); !ok {
-		return &ValidationError{Name: "repo", err: errors.New(`ent: missing required edge "DeploymentStatus.repo"`)}
 	}
 	return nil
 }

--- a/model/ent/deploymentstatus_create.go
+++ b/model/ent/deploymentstatus_create.go
@@ -12,6 +12,7 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/gitploy-io/gitploy/model/ent/deployment"
 	"github.com/gitploy-io/gitploy/model/ent/deploymentstatus"
+	"github.com/gitploy-io/gitploy/model/ent/event"
 )
 
 // DeploymentStatusCreate is the builder for creating a DeploymentStatus entity.
@@ -92,6 +93,21 @@ func (dsc *DeploymentStatusCreate) SetDeploymentID(i int) *DeploymentStatusCreat
 // SetDeployment sets the "deployment" edge to the Deployment entity.
 func (dsc *DeploymentStatusCreate) SetDeployment(d *Deployment) *DeploymentStatusCreate {
 	return dsc.SetDeploymentID(d.ID)
+}
+
+// AddEventIDs adds the "event" edge to the Event entity by IDs.
+func (dsc *DeploymentStatusCreate) AddEventIDs(ids ...int) *DeploymentStatusCreate {
+	dsc.mutation.AddEventIDs(ids...)
+	return dsc
+}
+
+// AddEvent adds the "event" edges to the Event entity.
+func (dsc *DeploymentStatusCreate) AddEvent(e ...*Event) *DeploymentStatusCreate {
+	ids := make([]int, len(e))
+	for i := range e {
+		ids[i] = e[i].ID
+	}
+	return dsc.AddEventIDs(ids...)
 }
 
 // Mutation returns the DeploymentStatusMutation object of the builder.
@@ -277,6 +293,25 @@ func (dsc *DeploymentStatusCreate) createSpec() (*DeploymentStatus, *sqlgraph.Cr
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
 		_node.DeploymentID = nodes[0]
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := dsc.mutation.EventIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   deploymentstatus.EventTable,
+			Columns: []string{deploymentstatus.EventColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt,
+					Column: event.FieldID,
+				},
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	return _node, _spec

--- a/model/ent/deploymentstatus_update.go
+++ b/model/ent/deploymentstatus_update.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gitploy-io/gitploy/model/ent/deploymentstatus"
 	"github.com/gitploy-io/gitploy/model/ent/event"
 	"github.com/gitploy-io/gitploy/model/ent/predicate"
+	"github.com/gitploy-io/gitploy/model/ent/repo"
 )
 
 // DeploymentStatusUpdate is the builder for updating DeploymentStatus entities.
@@ -102,9 +103,20 @@ func (dsu *DeploymentStatusUpdate) SetDeploymentID(i int) *DeploymentStatusUpdat
 	return dsu
 }
 
+// SetRepoID sets the "repo_id" field.
+func (dsu *DeploymentStatusUpdate) SetRepoID(i int64) *DeploymentStatusUpdate {
+	dsu.mutation.SetRepoID(i)
+	return dsu
+}
+
 // SetDeployment sets the "deployment" edge to the Deployment entity.
 func (dsu *DeploymentStatusUpdate) SetDeployment(d *Deployment) *DeploymentStatusUpdate {
 	return dsu.SetDeploymentID(d.ID)
+}
+
+// SetRepo sets the "repo" edge to the Repo entity.
+func (dsu *DeploymentStatusUpdate) SetRepo(r *Repo) *DeploymentStatusUpdate {
+	return dsu.SetRepoID(r.ID)
 }
 
 // AddEventIDs adds the "event" edge to the Event entity by IDs.
@@ -130,6 +142,12 @@ func (dsu *DeploymentStatusUpdate) Mutation() *DeploymentStatusMutation {
 // ClearDeployment clears the "deployment" edge to the Deployment entity.
 func (dsu *DeploymentStatusUpdate) ClearDeployment() *DeploymentStatusUpdate {
 	dsu.mutation.ClearDeployment()
+	return dsu
+}
+
+// ClearRepo clears the "repo" edge to the Repo entity.
+func (dsu *DeploymentStatusUpdate) ClearRepo() *DeploymentStatusUpdate {
+	dsu.mutation.ClearRepo()
 	return dsu
 }
 
@@ -228,6 +246,9 @@ func (dsu *DeploymentStatusUpdate) check() error {
 	if _, ok := dsu.mutation.DeploymentID(); dsu.mutation.DeploymentCleared() && !ok {
 		return errors.New(`ent: clearing a required unique edge "DeploymentStatus.deployment"`)
 	}
+	if _, ok := dsu.mutation.RepoID(); dsu.mutation.RepoCleared() && !ok {
+		return errors.New(`ent: clearing a required unique edge "DeploymentStatus.repo"`)
+	}
 	return nil
 }
 
@@ -323,6 +344,41 @@ func (dsu *DeploymentStatusUpdate) sqlSave(ctx context.Context) (n int, err erro
 				IDSpec: &sqlgraph.FieldSpec{
 					Type:   field.TypeInt,
 					Column: deployment.FieldID,
+				},
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if dsu.mutation.RepoCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   deploymentstatus.RepoTable,
+			Columns: []string{deploymentstatus.RepoColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt64,
+					Column: repo.FieldID,
+				},
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := dsu.mutation.RepoIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   deploymentstatus.RepoTable,
+			Columns: []string{deploymentstatus.RepoColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt64,
+					Column: repo.FieldID,
 				},
 			},
 		}
@@ -476,9 +532,20 @@ func (dsuo *DeploymentStatusUpdateOne) SetDeploymentID(i int) *DeploymentStatusU
 	return dsuo
 }
 
+// SetRepoID sets the "repo_id" field.
+func (dsuo *DeploymentStatusUpdateOne) SetRepoID(i int64) *DeploymentStatusUpdateOne {
+	dsuo.mutation.SetRepoID(i)
+	return dsuo
+}
+
 // SetDeployment sets the "deployment" edge to the Deployment entity.
 func (dsuo *DeploymentStatusUpdateOne) SetDeployment(d *Deployment) *DeploymentStatusUpdateOne {
 	return dsuo.SetDeploymentID(d.ID)
+}
+
+// SetRepo sets the "repo" edge to the Repo entity.
+func (dsuo *DeploymentStatusUpdateOne) SetRepo(r *Repo) *DeploymentStatusUpdateOne {
+	return dsuo.SetRepoID(r.ID)
 }
 
 // AddEventIDs adds the "event" edge to the Event entity by IDs.
@@ -504,6 +571,12 @@ func (dsuo *DeploymentStatusUpdateOne) Mutation() *DeploymentStatusMutation {
 // ClearDeployment clears the "deployment" edge to the Deployment entity.
 func (dsuo *DeploymentStatusUpdateOne) ClearDeployment() *DeploymentStatusUpdateOne {
 	dsuo.mutation.ClearDeployment()
+	return dsuo
+}
+
+// ClearRepo clears the "repo" edge to the Repo entity.
+func (dsuo *DeploymentStatusUpdateOne) ClearRepo() *DeploymentStatusUpdateOne {
+	dsuo.mutation.ClearRepo()
 	return dsuo
 }
 
@@ -608,6 +681,9 @@ func (dsuo *DeploymentStatusUpdateOne) defaults() {
 func (dsuo *DeploymentStatusUpdateOne) check() error {
 	if _, ok := dsuo.mutation.DeploymentID(); dsuo.mutation.DeploymentCleared() && !ok {
 		return errors.New(`ent: clearing a required unique edge "DeploymentStatus.deployment"`)
+	}
+	if _, ok := dsuo.mutation.RepoID(); dsuo.mutation.RepoCleared() && !ok {
+		return errors.New(`ent: clearing a required unique edge "DeploymentStatus.repo"`)
 	}
 	return nil
 }
@@ -721,6 +797,41 @@ func (dsuo *DeploymentStatusUpdateOne) sqlSave(ctx context.Context) (_node *Depl
 				IDSpec: &sqlgraph.FieldSpec{
 					Type:   field.TypeInt,
 					Column: deployment.FieldID,
+				},
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if dsuo.mutation.RepoCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   deploymentstatus.RepoTable,
+			Columns: []string{deploymentstatus.RepoColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt64,
+					Column: repo.FieldID,
+				},
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := dsuo.mutation.RepoIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   deploymentstatus.RepoTable,
+			Columns: []string{deploymentstatus.RepoColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt64,
+					Column: repo.FieldID,
 				},
 			},
 		}

--- a/model/ent/deploymentstatus_update.go
+++ b/model/ent/deploymentstatus_update.go
@@ -109,6 +109,20 @@ func (dsu *DeploymentStatusUpdate) SetRepoID(i int64) *DeploymentStatusUpdate {
 	return dsu
 }
 
+// SetNillableRepoID sets the "repo_id" field if the given value is not nil.
+func (dsu *DeploymentStatusUpdate) SetNillableRepoID(i *int64) *DeploymentStatusUpdate {
+	if i != nil {
+		dsu.SetRepoID(*i)
+	}
+	return dsu
+}
+
+// ClearRepoID clears the value of the "repo_id" field.
+func (dsu *DeploymentStatusUpdate) ClearRepoID() *DeploymentStatusUpdate {
+	dsu.mutation.ClearRepoID()
+	return dsu
+}
+
 // SetDeployment sets the "deployment" edge to the Deployment entity.
 func (dsu *DeploymentStatusUpdate) SetDeployment(d *Deployment) *DeploymentStatusUpdate {
 	return dsu.SetDeploymentID(d.ID)
@@ -245,9 +259,6 @@ func (dsu *DeploymentStatusUpdate) defaults() {
 func (dsu *DeploymentStatusUpdate) check() error {
 	if _, ok := dsu.mutation.DeploymentID(); dsu.mutation.DeploymentCleared() && !ok {
 		return errors.New(`ent: clearing a required unique edge "DeploymentStatus.deployment"`)
-	}
-	if _, ok := dsu.mutation.RepoID(); dsu.mutation.RepoCleared() && !ok {
-		return errors.New(`ent: clearing a required unique edge "DeploymentStatus.repo"`)
 	}
 	return nil
 }
@@ -538,6 +549,20 @@ func (dsuo *DeploymentStatusUpdateOne) SetRepoID(i int64) *DeploymentStatusUpdat
 	return dsuo
 }
 
+// SetNillableRepoID sets the "repo_id" field if the given value is not nil.
+func (dsuo *DeploymentStatusUpdateOne) SetNillableRepoID(i *int64) *DeploymentStatusUpdateOne {
+	if i != nil {
+		dsuo.SetRepoID(*i)
+	}
+	return dsuo
+}
+
+// ClearRepoID clears the value of the "repo_id" field.
+func (dsuo *DeploymentStatusUpdateOne) ClearRepoID() *DeploymentStatusUpdateOne {
+	dsuo.mutation.ClearRepoID()
+	return dsuo
+}
+
 // SetDeployment sets the "deployment" edge to the Deployment entity.
 func (dsuo *DeploymentStatusUpdateOne) SetDeployment(d *Deployment) *DeploymentStatusUpdateOne {
 	return dsuo.SetDeploymentID(d.ID)
@@ -681,9 +706,6 @@ func (dsuo *DeploymentStatusUpdateOne) defaults() {
 func (dsuo *DeploymentStatusUpdateOne) check() error {
 	if _, ok := dsuo.mutation.DeploymentID(); dsuo.mutation.DeploymentCleared() && !ok {
 		return errors.New(`ent: clearing a required unique edge "DeploymentStatus.deployment"`)
-	}
-	if _, ok := dsuo.mutation.RepoID(); dsuo.mutation.RepoCleared() && !ok {
-		return errors.New(`ent: clearing a required unique edge "DeploymentStatus.repo"`)
 	}
 	return nil
 }

--- a/model/ent/deploymentstatus_update.go
+++ b/model/ent/deploymentstatus_update.go
@@ -13,6 +13,7 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/gitploy-io/gitploy/model/ent/deployment"
 	"github.com/gitploy-io/gitploy/model/ent/deploymentstatus"
+	"github.com/gitploy-io/gitploy/model/ent/event"
 	"github.com/gitploy-io/gitploy/model/ent/predicate"
 )
 
@@ -106,6 +107,21 @@ func (dsu *DeploymentStatusUpdate) SetDeployment(d *Deployment) *DeploymentStatu
 	return dsu.SetDeploymentID(d.ID)
 }
 
+// AddEventIDs adds the "event" edge to the Event entity by IDs.
+func (dsu *DeploymentStatusUpdate) AddEventIDs(ids ...int) *DeploymentStatusUpdate {
+	dsu.mutation.AddEventIDs(ids...)
+	return dsu
+}
+
+// AddEvent adds the "event" edges to the Event entity.
+func (dsu *DeploymentStatusUpdate) AddEvent(e ...*Event) *DeploymentStatusUpdate {
+	ids := make([]int, len(e))
+	for i := range e {
+		ids[i] = e[i].ID
+	}
+	return dsu.AddEventIDs(ids...)
+}
+
 // Mutation returns the DeploymentStatusMutation object of the builder.
 func (dsu *DeploymentStatusUpdate) Mutation() *DeploymentStatusMutation {
 	return dsu.mutation
@@ -115,6 +131,27 @@ func (dsu *DeploymentStatusUpdate) Mutation() *DeploymentStatusMutation {
 func (dsu *DeploymentStatusUpdate) ClearDeployment() *DeploymentStatusUpdate {
 	dsu.mutation.ClearDeployment()
 	return dsu
+}
+
+// ClearEvent clears all "event" edges to the Event entity.
+func (dsu *DeploymentStatusUpdate) ClearEvent() *DeploymentStatusUpdate {
+	dsu.mutation.ClearEvent()
+	return dsu
+}
+
+// RemoveEventIDs removes the "event" edge to Event entities by IDs.
+func (dsu *DeploymentStatusUpdate) RemoveEventIDs(ids ...int) *DeploymentStatusUpdate {
+	dsu.mutation.RemoveEventIDs(ids...)
+	return dsu
+}
+
+// RemoveEvent removes "event" edges to Event entities.
+func (dsu *DeploymentStatusUpdate) RemoveEvent(e ...*Event) *DeploymentStatusUpdate {
+	ids := make([]int, len(e))
+	for i := range e {
+		ids[i] = e[i].ID
+	}
+	return dsu.RemoveEventIDs(ids...)
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
@@ -294,6 +331,60 @@ func (dsu *DeploymentStatusUpdate) sqlSave(ctx context.Context) (n int, err erro
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
+	if dsu.mutation.EventCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   deploymentstatus.EventTable,
+			Columns: []string{deploymentstatus.EventColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt,
+					Column: event.FieldID,
+				},
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := dsu.mutation.RemovedEventIDs(); len(nodes) > 0 && !dsu.mutation.EventCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   deploymentstatus.EventTable,
+			Columns: []string{deploymentstatus.EventColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt,
+					Column: event.FieldID,
+				},
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := dsu.mutation.EventIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   deploymentstatus.EventTable,
+			Columns: []string{deploymentstatus.EventColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt,
+					Column: event.FieldID,
+				},
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
 	if n, err = sqlgraph.UpdateNodes(ctx, dsu.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{deploymentstatus.Label}
@@ -390,6 +481,21 @@ func (dsuo *DeploymentStatusUpdateOne) SetDeployment(d *Deployment) *DeploymentS
 	return dsuo.SetDeploymentID(d.ID)
 }
 
+// AddEventIDs adds the "event" edge to the Event entity by IDs.
+func (dsuo *DeploymentStatusUpdateOne) AddEventIDs(ids ...int) *DeploymentStatusUpdateOne {
+	dsuo.mutation.AddEventIDs(ids...)
+	return dsuo
+}
+
+// AddEvent adds the "event" edges to the Event entity.
+func (dsuo *DeploymentStatusUpdateOne) AddEvent(e ...*Event) *DeploymentStatusUpdateOne {
+	ids := make([]int, len(e))
+	for i := range e {
+		ids[i] = e[i].ID
+	}
+	return dsuo.AddEventIDs(ids...)
+}
+
 // Mutation returns the DeploymentStatusMutation object of the builder.
 func (dsuo *DeploymentStatusUpdateOne) Mutation() *DeploymentStatusMutation {
 	return dsuo.mutation
@@ -399,6 +505,27 @@ func (dsuo *DeploymentStatusUpdateOne) Mutation() *DeploymentStatusMutation {
 func (dsuo *DeploymentStatusUpdateOne) ClearDeployment() *DeploymentStatusUpdateOne {
 	dsuo.mutation.ClearDeployment()
 	return dsuo
+}
+
+// ClearEvent clears all "event" edges to the Event entity.
+func (dsuo *DeploymentStatusUpdateOne) ClearEvent() *DeploymentStatusUpdateOne {
+	dsuo.mutation.ClearEvent()
+	return dsuo
+}
+
+// RemoveEventIDs removes the "event" edge to Event entities by IDs.
+func (dsuo *DeploymentStatusUpdateOne) RemoveEventIDs(ids ...int) *DeploymentStatusUpdateOne {
+	dsuo.mutation.RemoveEventIDs(ids...)
+	return dsuo
+}
+
+// RemoveEvent removes "event" edges to Event entities.
+func (dsuo *DeploymentStatusUpdateOne) RemoveEvent(e ...*Event) *DeploymentStatusUpdateOne {
+	ids := make([]int, len(e))
+	for i := range e {
+		ids[i] = e[i].ID
+	}
+	return dsuo.RemoveEventIDs(ids...)
 }
 
 // Select allows selecting one or more fields (columns) of the returned entity.
@@ -594,6 +721,60 @@ func (dsuo *DeploymentStatusUpdateOne) sqlSave(ctx context.Context) (_node *Depl
 				IDSpec: &sqlgraph.FieldSpec{
 					Type:   field.TypeInt,
 					Column: deployment.FieldID,
+				},
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if dsuo.mutation.EventCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   deploymentstatus.EventTable,
+			Columns: []string{deploymentstatus.EventColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt,
+					Column: event.FieldID,
+				},
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := dsuo.mutation.RemovedEventIDs(); len(nodes) > 0 && !dsuo.mutation.EventCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   deploymentstatus.EventTable,
+			Columns: []string{deploymentstatus.EventColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt,
+					Column: event.FieldID,
+				},
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := dsuo.mutation.EventIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   deploymentstatus.EventTable,
+			Columns: []string{deploymentstatus.EventColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt,
+					Column: event.FieldID,
 				},
 			},
 		}

--- a/model/ent/event/event.go
+++ b/model/ent/event/event.go
@@ -18,16 +18,12 @@ const (
 	FieldType = "type"
 	// FieldCreatedAt holds the string denoting the created_at field in the database.
 	FieldCreatedAt = "created_at"
-	// FieldDeploymentID holds the string denoting the deployment_id field in the database.
-	FieldDeploymentID = "deployment_id"
 	// FieldDeploymentStatusID holds the string denoting the deployment_status_id field in the database.
 	FieldDeploymentStatusID = "deployment_status_id"
 	// FieldReviewID holds the string denoting the review_id field in the database.
 	FieldReviewID = "review_id"
 	// FieldDeletedID holds the string denoting the deleted_id field in the database.
 	FieldDeletedID = "deleted_id"
-	// EdgeDeployment holds the string denoting the deployment edge name in mutations.
-	EdgeDeployment = "deployment"
 	// EdgeDeploymentStatus holds the string denoting the deployment_status edge name in mutations.
 	EdgeDeploymentStatus = "deployment_status"
 	// EdgeReview holds the string denoting the review edge name in mutations.
@@ -36,13 +32,6 @@ const (
 	EdgeNotificationRecord = "notification_record"
 	// Table holds the table name of the event in the database.
 	Table = "events"
-	// DeploymentTable is the table that holds the deployment relation/edge.
-	DeploymentTable = "events"
-	// DeploymentInverseTable is the table name for the Deployment entity.
-	// It exists in this package in order to avoid circular dependency with the "deployment" package.
-	DeploymentInverseTable = "deployments"
-	// DeploymentColumn is the table column denoting the deployment relation/edge.
-	DeploymentColumn = "deployment_id"
 	// DeploymentStatusTable is the table that holds the deployment_status relation/edge.
 	DeploymentStatusTable = "events"
 	// DeploymentStatusInverseTable is the table name for the DeploymentStatus entity.
@@ -72,7 +61,6 @@ var Columns = []string{
 	FieldKind,
 	FieldType,
 	FieldCreatedAt,
-	FieldDeploymentID,
 	FieldDeploymentStatusID,
 	FieldReviewID,
 	FieldDeletedID,
@@ -98,7 +86,6 @@ type Kind string
 
 // Kind values.
 const (
-	KindDeployment       Kind = "deployment"
 	KindDeploymentStatus Kind = "deployment_status"
 	KindReview           Kind = "review"
 )
@@ -110,7 +97,7 @@ func (k Kind) String() string {
 // KindValidator is a validator for the "kind" field enum values. It is called by the builders before save.
 func KindValidator(k Kind) error {
 	switch k {
-	case KindDeployment, KindDeploymentStatus, KindReview:
+	case KindDeploymentStatus, KindReview:
 		return nil
 	default:
 		return fmt.Errorf("event: invalid enum value for kind field: %q", k)

--- a/model/ent/event/event.go
+++ b/model/ent/event/event.go
@@ -20,12 +20,16 @@ const (
 	FieldCreatedAt = "created_at"
 	// FieldDeploymentID holds the string denoting the deployment_id field in the database.
 	FieldDeploymentID = "deployment_id"
+	// FieldDeploymentStatusID holds the string denoting the deployment_status_id field in the database.
+	FieldDeploymentStatusID = "deployment_status_id"
 	// FieldReviewID holds the string denoting the review_id field in the database.
 	FieldReviewID = "review_id"
 	// FieldDeletedID holds the string denoting the deleted_id field in the database.
 	FieldDeletedID = "deleted_id"
 	// EdgeDeployment holds the string denoting the deployment edge name in mutations.
 	EdgeDeployment = "deployment"
+	// EdgeDeploymentStatus holds the string denoting the deployment_status edge name in mutations.
+	EdgeDeploymentStatus = "deployment_status"
 	// EdgeReview holds the string denoting the review edge name in mutations.
 	EdgeReview = "review"
 	// EdgeNotificationRecord holds the string denoting the notification_record edge name in mutations.
@@ -39,6 +43,13 @@ const (
 	DeploymentInverseTable = "deployments"
 	// DeploymentColumn is the table column denoting the deployment relation/edge.
 	DeploymentColumn = "deployment_id"
+	// DeploymentStatusTable is the table that holds the deployment_status relation/edge.
+	DeploymentStatusTable = "events"
+	// DeploymentStatusInverseTable is the table name for the DeploymentStatus entity.
+	// It exists in this package in order to avoid circular dependency with the "deploymentstatus" package.
+	DeploymentStatusInverseTable = "deployment_status"
+	// DeploymentStatusColumn is the table column denoting the deployment_status relation/edge.
+	DeploymentStatusColumn = "deployment_status_id"
 	// ReviewTable is the table that holds the review relation/edge.
 	ReviewTable = "events"
 	// ReviewInverseTable is the table name for the Review entity.
@@ -62,6 +73,7 @@ var Columns = []string{
 	FieldType,
 	FieldCreatedAt,
 	FieldDeploymentID,
+	FieldDeploymentStatusID,
 	FieldReviewID,
 	FieldDeletedID,
 }
@@ -86,9 +98,9 @@ type Kind string
 
 // Kind values.
 const (
-	KindDeployment Kind = "deployment"
-	KindReview     Kind = "review"
-	KindApproval   Kind = "approval"
+	KindDeployment       Kind = "deployment"
+	KindDeploymentStatus Kind = "deployment_status"
+	KindReview           Kind = "review"
 )
 
 func (k Kind) String() string {
@@ -98,7 +110,7 @@ func (k Kind) String() string {
 // KindValidator is a validator for the "kind" field enum values. It is called by the builders before save.
 func KindValidator(k Kind) error {
 	switch k {
-	case KindDeployment, KindReview, KindApproval:
+	case KindDeployment, KindDeploymentStatus, KindReview:
 		return nil
 	default:
 		return fmt.Errorf("event: invalid enum value for kind field: %q", k)

--- a/model/ent/event/where.go
+++ b/model/ent/event/where.go
@@ -107,6 +107,13 @@ func DeploymentID(v int) predicate.Event {
 	})
 }
 
+// DeploymentStatusID applies equality check predicate on the "deployment_status_id" field. It's identical to DeploymentStatusIDEQ.
+func DeploymentStatusID(v int) predicate.Event {
+	return predicate.Event(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldDeploymentStatusID), v))
+	})
+}
+
 // ReviewID applies equality check predicate on the "review_id" field. It's identical to ReviewIDEQ.
 func ReviewID(v int) predicate.Event {
 	return predicate.Event(func(s *sql.Selector) {
@@ -355,6 +362,68 @@ func DeploymentIDNotNil() predicate.Event {
 	})
 }
 
+// DeploymentStatusIDEQ applies the EQ predicate on the "deployment_status_id" field.
+func DeploymentStatusIDEQ(v int) predicate.Event {
+	return predicate.Event(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldDeploymentStatusID), v))
+	})
+}
+
+// DeploymentStatusIDNEQ applies the NEQ predicate on the "deployment_status_id" field.
+func DeploymentStatusIDNEQ(v int) predicate.Event {
+	return predicate.Event(func(s *sql.Selector) {
+		s.Where(sql.NEQ(s.C(FieldDeploymentStatusID), v))
+	})
+}
+
+// DeploymentStatusIDIn applies the In predicate on the "deployment_status_id" field.
+func DeploymentStatusIDIn(vs ...int) predicate.Event {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.Event(func(s *sql.Selector) {
+		// if not arguments were provided, append the FALSE constants,
+		// since we can't apply "IN ()". This will make this predicate falsy.
+		if len(v) == 0 {
+			s.Where(sql.False())
+			return
+		}
+		s.Where(sql.In(s.C(FieldDeploymentStatusID), v...))
+	})
+}
+
+// DeploymentStatusIDNotIn applies the NotIn predicate on the "deployment_status_id" field.
+func DeploymentStatusIDNotIn(vs ...int) predicate.Event {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.Event(func(s *sql.Selector) {
+		// if not arguments were provided, append the FALSE constants,
+		// since we can't apply "IN ()". This will make this predicate falsy.
+		if len(v) == 0 {
+			s.Where(sql.False())
+			return
+		}
+		s.Where(sql.NotIn(s.C(FieldDeploymentStatusID), v...))
+	})
+}
+
+// DeploymentStatusIDIsNil applies the IsNil predicate on the "deployment_status_id" field.
+func DeploymentStatusIDIsNil() predicate.Event {
+	return predicate.Event(func(s *sql.Selector) {
+		s.Where(sql.IsNull(s.C(FieldDeploymentStatusID)))
+	})
+}
+
+// DeploymentStatusIDNotNil applies the NotNil predicate on the "deployment_status_id" field.
+func DeploymentStatusIDNotNil() predicate.Event {
+	return predicate.Event(func(s *sql.Selector) {
+		s.Where(sql.NotNull(s.C(FieldDeploymentStatusID)))
+	})
+}
+
 // ReviewIDEQ applies the EQ predicate on the "review_id" field.
 func ReviewIDEQ(v int) predicate.Event {
 	return predicate.Event(func(s *sql.Selector) {
@@ -526,6 +595,34 @@ func HasDeploymentWith(preds ...predicate.Deployment) predicate.Event {
 			sqlgraph.From(Table, FieldID),
 			sqlgraph.To(DeploymentInverseTable, FieldID),
 			sqlgraph.Edge(sqlgraph.M2O, true, DeploymentTable, DeploymentColumn),
+		)
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasDeploymentStatus applies the HasEdge predicate on the "deployment_status" edge.
+func HasDeploymentStatus() predicate.Event {
+	return predicate.Event(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.To(DeploymentStatusTable, FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, DeploymentStatusTable, DeploymentStatusColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasDeploymentStatusWith applies the HasEdge predicate on the "deployment_status" edge with a given conditions (other predicates).
+func HasDeploymentStatusWith(preds ...predicate.DeploymentStatus) predicate.Event {
+	return predicate.Event(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.To(DeploymentStatusInverseTable, FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, DeploymentStatusTable, DeploymentStatusColumn),
 		)
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {

--- a/model/ent/event/where.go
+++ b/model/ent/event/where.go
@@ -100,13 +100,6 @@ func CreatedAt(v time.Time) predicate.Event {
 	})
 }
 
-// DeploymentID applies equality check predicate on the "deployment_id" field. It's identical to DeploymentIDEQ.
-func DeploymentID(v int) predicate.Event {
-	return predicate.Event(func(s *sql.Selector) {
-		s.Where(sql.EQ(s.C(FieldDeploymentID), v))
-	})
-}
-
 // DeploymentStatusID applies equality check predicate on the "deployment_status_id" field. It's identical to DeploymentStatusIDEQ.
 func DeploymentStatusID(v int) predicate.Event {
 	return predicate.Event(func(s *sql.Selector) {
@@ -297,68 +290,6 @@ func CreatedAtLT(v time.Time) predicate.Event {
 func CreatedAtLTE(v time.Time) predicate.Event {
 	return predicate.Event(func(s *sql.Selector) {
 		s.Where(sql.LTE(s.C(FieldCreatedAt), v))
-	})
-}
-
-// DeploymentIDEQ applies the EQ predicate on the "deployment_id" field.
-func DeploymentIDEQ(v int) predicate.Event {
-	return predicate.Event(func(s *sql.Selector) {
-		s.Where(sql.EQ(s.C(FieldDeploymentID), v))
-	})
-}
-
-// DeploymentIDNEQ applies the NEQ predicate on the "deployment_id" field.
-func DeploymentIDNEQ(v int) predicate.Event {
-	return predicate.Event(func(s *sql.Selector) {
-		s.Where(sql.NEQ(s.C(FieldDeploymentID), v))
-	})
-}
-
-// DeploymentIDIn applies the In predicate on the "deployment_id" field.
-func DeploymentIDIn(vs ...int) predicate.Event {
-	v := make([]interface{}, len(vs))
-	for i := range v {
-		v[i] = vs[i]
-	}
-	return predicate.Event(func(s *sql.Selector) {
-		// if not arguments were provided, append the FALSE constants,
-		// since we can't apply "IN ()". This will make this predicate falsy.
-		if len(v) == 0 {
-			s.Where(sql.False())
-			return
-		}
-		s.Where(sql.In(s.C(FieldDeploymentID), v...))
-	})
-}
-
-// DeploymentIDNotIn applies the NotIn predicate on the "deployment_id" field.
-func DeploymentIDNotIn(vs ...int) predicate.Event {
-	v := make([]interface{}, len(vs))
-	for i := range v {
-		v[i] = vs[i]
-	}
-	return predicate.Event(func(s *sql.Selector) {
-		// if not arguments were provided, append the FALSE constants,
-		// since we can't apply "IN ()". This will make this predicate falsy.
-		if len(v) == 0 {
-			s.Where(sql.False())
-			return
-		}
-		s.Where(sql.NotIn(s.C(FieldDeploymentID), v...))
-	})
-}
-
-// DeploymentIDIsNil applies the IsNil predicate on the "deployment_id" field.
-func DeploymentIDIsNil() predicate.Event {
-	return predicate.Event(func(s *sql.Selector) {
-		s.Where(sql.IsNull(s.C(FieldDeploymentID)))
-	})
-}
-
-// DeploymentIDNotNil applies the NotNil predicate on the "deployment_id" field.
-func DeploymentIDNotNil() predicate.Event {
-	return predicate.Event(func(s *sql.Selector) {
-		s.Where(sql.NotNull(s.C(FieldDeploymentID)))
 	})
 }
 
@@ -573,34 +504,6 @@ func DeletedIDIsNil() predicate.Event {
 func DeletedIDNotNil() predicate.Event {
 	return predicate.Event(func(s *sql.Selector) {
 		s.Where(sql.NotNull(s.C(FieldDeletedID)))
-	})
-}
-
-// HasDeployment applies the HasEdge predicate on the "deployment" edge.
-func HasDeployment() predicate.Event {
-	return predicate.Event(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(DeploymentTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, DeploymentTable, DeploymentColumn),
-		)
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasDeploymentWith applies the HasEdge predicate on the "deployment" edge with a given conditions (other predicates).
-func HasDeploymentWith(preds ...predicate.Deployment) predicate.Event {
-	return predicate.Event(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(DeploymentInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, DeploymentTable, DeploymentColumn),
-		)
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
 	})
 }
 

--- a/model/ent/event_create.go
+++ b/model/ent/event_create.go
@@ -10,7 +10,6 @@ import (
 
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
-	"github.com/gitploy-io/gitploy/model/ent/deployment"
 	"github.com/gitploy-io/gitploy/model/ent/deploymentstatus"
 	"github.com/gitploy-io/gitploy/model/ent/event"
 	"github.com/gitploy-io/gitploy/model/ent/notificationrecord"
@@ -46,20 +45,6 @@ func (ec *EventCreate) SetCreatedAt(t time.Time) *EventCreate {
 func (ec *EventCreate) SetNillableCreatedAt(t *time.Time) *EventCreate {
 	if t != nil {
 		ec.SetCreatedAt(*t)
-	}
-	return ec
-}
-
-// SetDeploymentID sets the "deployment_id" field.
-func (ec *EventCreate) SetDeploymentID(i int) *EventCreate {
-	ec.mutation.SetDeploymentID(i)
-	return ec
-}
-
-// SetNillableDeploymentID sets the "deployment_id" field if the given value is not nil.
-func (ec *EventCreate) SetNillableDeploymentID(i *int) *EventCreate {
-	if i != nil {
-		ec.SetDeploymentID(*i)
 	}
 	return ec
 }
@@ -104,11 +89,6 @@ func (ec *EventCreate) SetNillableDeletedID(i *int) *EventCreate {
 		ec.SetDeletedID(*i)
 	}
 	return ec
-}
-
-// SetDeployment sets the "deployment" edge to the Deployment entity.
-func (ec *EventCreate) SetDeployment(d *Deployment) *EventCreate {
-	return ec.SetDeploymentID(d.ID)
 }
 
 // SetDeploymentStatus sets the "deployment_status" edge to the DeploymentStatus entity.
@@ -296,26 +276,6 @@ func (ec *EventCreate) createSpec() (*Event, *sqlgraph.CreateSpec) {
 			Column: event.FieldDeletedID,
 		})
 		_node.DeletedID = value
-	}
-	if nodes := ec.mutation.DeploymentIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: true,
-			Table:   event.DeploymentTable,
-			Columns: []string{event.DeploymentColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: &sqlgraph.FieldSpec{
-					Type:   field.TypeInt,
-					Column: deployment.FieldID,
-				},
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_node.DeploymentID = nodes[0]
-		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := ec.mutation.DeploymentStatusIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/model/ent/event_create.go
+++ b/model/ent/event_create.go
@@ -11,6 +11,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/gitploy-io/gitploy/model/ent/deployment"
+	"github.com/gitploy-io/gitploy/model/ent/deploymentstatus"
 	"github.com/gitploy-io/gitploy/model/ent/event"
 	"github.com/gitploy-io/gitploy/model/ent/notificationrecord"
 	"github.com/gitploy-io/gitploy/model/ent/review"
@@ -63,6 +64,20 @@ func (ec *EventCreate) SetNillableDeploymentID(i *int) *EventCreate {
 	return ec
 }
 
+// SetDeploymentStatusID sets the "deployment_status_id" field.
+func (ec *EventCreate) SetDeploymentStatusID(i int) *EventCreate {
+	ec.mutation.SetDeploymentStatusID(i)
+	return ec
+}
+
+// SetNillableDeploymentStatusID sets the "deployment_status_id" field if the given value is not nil.
+func (ec *EventCreate) SetNillableDeploymentStatusID(i *int) *EventCreate {
+	if i != nil {
+		ec.SetDeploymentStatusID(*i)
+	}
+	return ec
+}
+
 // SetReviewID sets the "review_id" field.
 func (ec *EventCreate) SetReviewID(i int) *EventCreate {
 	ec.mutation.SetReviewID(i)
@@ -94,6 +109,11 @@ func (ec *EventCreate) SetNillableDeletedID(i *int) *EventCreate {
 // SetDeployment sets the "deployment" edge to the Deployment entity.
 func (ec *EventCreate) SetDeployment(d *Deployment) *EventCreate {
 	return ec.SetDeploymentID(d.ID)
+}
+
+// SetDeploymentStatus sets the "deployment_status" edge to the DeploymentStatus entity.
+func (ec *EventCreate) SetDeploymentStatus(d *DeploymentStatus) *EventCreate {
+	return ec.SetDeploymentStatusID(d.ID)
 }
 
 // SetReview sets the "review" edge to the Review entity.
@@ -295,6 +315,26 @@ func (ec *EventCreate) createSpec() (*Event, *sqlgraph.CreateSpec) {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
 		_node.DeploymentID = nodes[0]
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := ec.mutation.DeploymentStatusIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   event.DeploymentStatusTable,
+			Columns: []string{event.DeploymentStatusColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt,
+					Column: deploymentstatus.FieldID,
+				},
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_node.DeploymentStatusID = nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := ec.mutation.ReviewIDs(); len(nodes) > 0 {

--- a/model/ent/event_query.go
+++ b/model/ent/event_query.go
@@ -13,7 +13,6 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
-	"github.com/gitploy-io/gitploy/model/ent/deployment"
 	"github.com/gitploy-io/gitploy/model/ent/deploymentstatus"
 	"github.com/gitploy-io/gitploy/model/ent/event"
 	"github.com/gitploy-io/gitploy/model/ent/notificationrecord"
@@ -31,7 +30,6 @@ type EventQuery struct {
 	fields     []string
 	predicates []predicate.Event
 	// eager-loading edges.
-	withDeployment         *DeploymentQuery
 	withDeploymentStatus   *DeploymentStatusQuery
 	withReview             *ReviewQuery
 	withNotificationRecord *NotificationRecordQuery
@@ -70,28 +68,6 @@ func (eq *EventQuery) Unique(unique bool) *EventQuery {
 func (eq *EventQuery) Order(o ...OrderFunc) *EventQuery {
 	eq.order = append(eq.order, o...)
 	return eq
-}
-
-// QueryDeployment chains the current query on the "deployment" edge.
-func (eq *EventQuery) QueryDeployment() *DeploymentQuery {
-	query := &DeploymentQuery{config: eq.config}
-	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
-		if err := eq.prepareQuery(ctx); err != nil {
-			return nil, err
-		}
-		selector := eq.sqlQuery(ctx)
-		if err := selector.Err(); err != nil {
-			return nil, err
-		}
-		step := sqlgraph.NewStep(
-			sqlgraph.From(event.Table, event.FieldID, selector),
-			sqlgraph.To(deployment.Table, deployment.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, event.DeploymentTable, event.DeploymentColumn),
-		)
-		fromU = sqlgraph.SetNeighbors(eq.driver.Dialect(), step)
-		return fromU, nil
-	}
-	return query
 }
 
 // QueryDeploymentStatus chains the current query on the "deployment_status" edge.
@@ -341,7 +317,6 @@ func (eq *EventQuery) Clone() *EventQuery {
 		offset:                 eq.offset,
 		order:                  append([]OrderFunc{}, eq.order...),
 		predicates:             append([]predicate.Event{}, eq.predicates...),
-		withDeployment:         eq.withDeployment.Clone(),
 		withDeploymentStatus:   eq.withDeploymentStatus.Clone(),
 		withReview:             eq.withReview.Clone(),
 		withNotificationRecord: eq.withNotificationRecord.Clone(),
@@ -350,17 +325,6 @@ func (eq *EventQuery) Clone() *EventQuery {
 		path:   eq.path,
 		unique: eq.unique,
 	}
-}
-
-// WithDeployment tells the query-builder to eager-load the nodes that are connected to
-// the "deployment" edge. The optional arguments are used to configure the query builder of the edge.
-func (eq *EventQuery) WithDeployment(opts ...func(*DeploymentQuery)) *EventQuery {
-	query := &DeploymentQuery{config: eq.config}
-	for _, opt := range opts {
-		opt(query)
-	}
-	eq.withDeployment = query
-	return eq
 }
 
 // WithDeploymentStatus tells the query-builder to eager-load the nodes that are connected to
@@ -461,8 +425,7 @@ func (eq *EventQuery) sqlAll(ctx context.Context) ([]*Event, error) {
 	var (
 		nodes       = []*Event{}
 		_spec       = eq.querySpec()
-		loadedTypes = [4]bool{
-			eq.withDeployment != nil,
+		loadedTypes = [3]bool{
 			eq.withDeploymentStatus != nil,
 			eq.withReview != nil,
 			eq.withNotificationRecord != nil,
@@ -489,32 +452,6 @@ func (eq *EventQuery) sqlAll(ctx context.Context) ([]*Event, error) {
 	}
 	if len(nodes) == 0 {
 		return nodes, nil
-	}
-
-	if query := eq.withDeployment; query != nil {
-		ids := make([]int, 0, len(nodes))
-		nodeids := make(map[int][]*Event)
-		for i := range nodes {
-			fk := nodes[i].DeploymentID
-			if _, ok := nodeids[fk]; !ok {
-				ids = append(ids, fk)
-			}
-			nodeids[fk] = append(nodeids[fk], nodes[i])
-		}
-		query.Where(deployment.IDIn(ids...))
-		neighbors, err := query.All(ctx)
-		if err != nil {
-			return nil, err
-		}
-		for _, n := range neighbors {
-			nodes, ok := nodeids[n.ID]
-			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "deployment_id" returned %v`, n.ID)
-			}
-			for i := range nodes {
-				nodes[i].Edges.Deployment = n
-			}
-		}
 	}
 
 	if query := eq.withDeploymentStatus; query != nil {

--- a/model/ent/event_query.go
+++ b/model/ent/event_query.go
@@ -14,6 +14,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/gitploy-io/gitploy/model/ent/deployment"
+	"github.com/gitploy-io/gitploy/model/ent/deploymentstatus"
 	"github.com/gitploy-io/gitploy/model/ent/event"
 	"github.com/gitploy-io/gitploy/model/ent/notificationrecord"
 	"github.com/gitploy-io/gitploy/model/ent/predicate"
@@ -31,6 +32,7 @@ type EventQuery struct {
 	predicates []predicate.Event
 	// eager-loading edges.
 	withDeployment         *DeploymentQuery
+	withDeploymentStatus   *DeploymentStatusQuery
 	withReview             *ReviewQuery
 	withNotificationRecord *NotificationRecordQuery
 	modifiers              []func(s *sql.Selector)
@@ -85,6 +87,28 @@ func (eq *EventQuery) QueryDeployment() *DeploymentQuery {
 			sqlgraph.From(event.Table, event.FieldID, selector),
 			sqlgraph.To(deployment.Table, deployment.FieldID),
 			sqlgraph.Edge(sqlgraph.M2O, true, event.DeploymentTable, event.DeploymentColumn),
+		)
+		fromU = sqlgraph.SetNeighbors(eq.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryDeploymentStatus chains the current query on the "deployment_status" edge.
+func (eq *EventQuery) QueryDeploymentStatus() *DeploymentStatusQuery {
+	query := &DeploymentStatusQuery{config: eq.config}
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := eq.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := eq.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(event.Table, event.FieldID, selector),
+			sqlgraph.To(deploymentstatus.Table, deploymentstatus.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, event.DeploymentStatusTable, event.DeploymentStatusColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(eq.driver.Dialect(), step)
 		return fromU, nil
@@ -318,6 +342,7 @@ func (eq *EventQuery) Clone() *EventQuery {
 		order:                  append([]OrderFunc{}, eq.order...),
 		predicates:             append([]predicate.Event{}, eq.predicates...),
 		withDeployment:         eq.withDeployment.Clone(),
+		withDeploymentStatus:   eq.withDeploymentStatus.Clone(),
 		withReview:             eq.withReview.Clone(),
 		withNotificationRecord: eq.withNotificationRecord.Clone(),
 		// clone intermediate query.
@@ -335,6 +360,17 @@ func (eq *EventQuery) WithDeployment(opts ...func(*DeploymentQuery)) *EventQuery
 		opt(query)
 	}
 	eq.withDeployment = query
+	return eq
+}
+
+// WithDeploymentStatus tells the query-builder to eager-load the nodes that are connected to
+// the "deployment_status" edge. The optional arguments are used to configure the query builder of the edge.
+func (eq *EventQuery) WithDeploymentStatus(opts ...func(*DeploymentStatusQuery)) *EventQuery {
+	query := &DeploymentStatusQuery{config: eq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	eq.withDeploymentStatus = query
 	return eq
 }
 
@@ -425,8 +461,9 @@ func (eq *EventQuery) sqlAll(ctx context.Context) ([]*Event, error) {
 	var (
 		nodes       = []*Event{}
 		_spec       = eq.querySpec()
-		loadedTypes = [3]bool{
+		loadedTypes = [4]bool{
 			eq.withDeployment != nil,
+			eq.withDeploymentStatus != nil,
 			eq.withReview != nil,
 			eq.withNotificationRecord != nil,
 		}
@@ -476,6 +513,32 @@ func (eq *EventQuery) sqlAll(ctx context.Context) ([]*Event, error) {
 			}
 			for i := range nodes {
 				nodes[i].Edges.Deployment = n
+			}
+		}
+	}
+
+	if query := eq.withDeploymentStatus; query != nil {
+		ids := make([]int, 0, len(nodes))
+		nodeids := make(map[int][]*Event)
+		for i := range nodes {
+			fk := nodes[i].DeploymentStatusID
+			if _, ok := nodeids[fk]; !ok {
+				ids = append(ids, fk)
+			}
+			nodeids[fk] = append(nodeids[fk], nodes[i])
+		}
+		query.Where(deploymentstatus.IDIn(ids...))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			nodes, ok := nodeids[n.ID]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected foreign-key "deployment_status_id" returned %v`, n.ID)
+			}
+			for i := range nodes {
+				nodes[i].Edges.DeploymentStatus = n
 			}
 		}
 	}

--- a/model/ent/event_update.go
+++ b/model/ent/event_update.go
@@ -11,7 +11,6 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
-	"github.com/gitploy-io/gitploy/model/ent/deployment"
 	"github.com/gitploy-io/gitploy/model/ent/deploymentstatus"
 	"github.com/gitploy-io/gitploy/model/ent/event"
 	"github.com/gitploy-io/gitploy/model/ent/notificationrecord"
@@ -55,26 +54,6 @@ func (eu *EventUpdate) SetNillableCreatedAt(t *time.Time) *EventUpdate {
 	if t != nil {
 		eu.SetCreatedAt(*t)
 	}
-	return eu
-}
-
-// SetDeploymentID sets the "deployment_id" field.
-func (eu *EventUpdate) SetDeploymentID(i int) *EventUpdate {
-	eu.mutation.SetDeploymentID(i)
-	return eu
-}
-
-// SetNillableDeploymentID sets the "deployment_id" field if the given value is not nil.
-func (eu *EventUpdate) SetNillableDeploymentID(i *int) *EventUpdate {
-	if i != nil {
-		eu.SetDeploymentID(*i)
-	}
-	return eu
-}
-
-// ClearDeploymentID clears the value of the "deployment_id" field.
-func (eu *EventUpdate) ClearDeploymentID() *EventUpdate {
-	eu.mutation.ClearDeploymentID()
 	return eu
 }
 
@@ -145,11 +124,6 @@ func (eu *EventUpdate) ClearDeletedID() *EventUpdate {
 	return eu
 }
 
-// SetDeployment sets the "deployment" edge to the Deployment entity.
-func (eu *EventUpdate) SetDeployment(d *Deployment) *EventUpdate {
-	return eu.SetDeploymentID(d.ID)
-}
-
 // SetDeploymentStatus sets the "deployment_status" edge to the DeploymentStatus entity.
 func (eu *EventUpdate) SetDeploymentStatus(d *DeploymentStatus) *EventUpdate {
 	return eu.SetDeploymentStatusID(d.ID)
@@ -182,12 +156,6 @@ func (eu *EventUpdate) SetNotificationRecord(n *NotificationRecord) *EventUpdate
 // Mutation returns the EventMutation object of the builder.
 func (eu *EventUpdate) Mutation() *EventMutation {
 	return eu.mutation
-}
-
-// ClearDeployment clears the "deployment" edge to the Deployment entity.
-func (eu *EventUpdate) ClearDeployment() *EventUpdate {
-	eu.mutation.ClearDeployment()
-	return eu
 }
 
 // ClearDeploymentStatus clears the "deployment_status" edge to the DeploymentStatus entity.
@@ -342,41 +310,6 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Column: event.FieldDeletedID,
 		})
 	}
-	if eu.mutation.DeploymentCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: true,
-			Table:   event.DeploymentTable,
-			Columns: []string{event.DeploymentColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: &sqlgraph.FieldSpec{
-					Type:   field.TypeInt,
-					Column: deployment.FieldID,
-				},
-			},
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := eu.mutation.DeploymentIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: true,
-			Table:   event.DeploymentTable,
-			Columns: []string{event.DeploymentColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: &sqlgraph.FieldSpec{
-					Type:   field.TypeInt,
-					Column: deployment.FieldID,
-				},
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
 	if eu.mutation.DeploymentStatusCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
@@ -527,26 +460,6 @@ func (euo *EventUpdateOne) SetNillableCreatedAt(t *time.Time) *EventUpdateOne {
 	return euo
 }
 
-// SetDeploymentID sets the "deployment_id" field.
-func (euo *EventUpdateOne) SetDeploymentID(i int) *EventUpdateOne {
-	euo.mutation.SetDeploymentID(i)
-	return euo
-}
-
-// SetNillableDeploymentID sets the "deployment_id" field if the given value is not nil.
-func (euo *EventUpdateOne) SetNillableDeploymentID(i *int) *EventUpdateOne {
-	if i != nil {
-		euo.SetDeploymentID(*i)
-	}
-	return euo
-}
-
-// ClearDeploymentID clears the value of the "deployment_id" field.
-func (euo *EventUpdateOne) ClearDeploymentID() *EventUpdateOne {
-	euo.mutation.ClearDeploymentID()
-	return euo
-}
-
 // SetDeploymentStatusID sets the "deployment_status_id" field.
 func (euo *EventUpdateOne) SetDeploymentStatusID(i int) *EventUpdateOne {
 	euo.mutation.SetDeploymentStatusID(i)
@@ -614,11 +527,6 @@ func (euo *EventUpdateOne) ClearDeletedID() *EventUpdateOne {
 	return euo
 }
 
-// SetDeployment sets the "deployment" edge to the Deployment entity.
-func (euo *EventUpdateOne) SetDeployment(d *Deployment) *EventUpdateOne {
-	return euo.SetDeploymentID(d.ID)
-}
-
 // SetDeploymentStatus sets the "deployment_status" edge to the DeploymentStatus entity.
 func (euo *EventUpdateOne) SetDeploymentStatus(d *DeploymentStatus) *EventUpdateOne {
 	return euo.SetDeploymentStatusID(d.ID)
@@ -651,12 +559,6 @@ func (euo *EventUpdateOne) SetNotificationRecord(n *NotificationRecord) *EventUp
 // Mutation returns the EventMutation object of the builder.
 func (euo *EventUpdateOne) Mutation() *EventMutation {
 	return euo.mutation
-}
-
-// ClearDeployment clears the "deployment" edge to the Deployment entity.
-func (euo *EventUpdateOne) ClearDeployment() *EventUpdateOne {
-	euo.mutation.ClearDeployment()
-	return euo
 }
 
 // ClearDeploymentStatus clears the "deployment_status" edge to the DeploymentStatus entity.
@@ -834,41 +736,6 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (_node *Event, err error
 			Type:   field.TypeInt,
 			Column: event.FieldDeletedID,
 		})
-	}
-	if euo.mutation.DeploymentCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: true,
-			Table:   event.DeploymentTable,
-			Columns: []string{event.DeploymentColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: &sqlgraph.FieldSpec{
-					Type:   field.TypeInt,
-					Column: deployment.FieldID,
-				},
-			},
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := euo.mutation.DeploymentIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: true,
-			Table:   event.DeploymentTable,
-			Columns: []string{event.DeploymentColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: &sqlgraph.FieldSpec{
-					Type:   field.TypeInt,
-					Column: deployment.FieldID,
-				},
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if euo.mutation.DeploymentStatusCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/model/ent/event_update.go
+++ b/model/ent/event_update.go
@@ -12,6 +12,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/gitploy-io/gitploy/model/ent/deployment"
+	"github.com/gitploy-io/gitploy/model/ent/deploymentstatus"
 	"github.com/gitploy-io/gitploy/model/ent/event"
 	"github.com/gitploy-io/gitploy/model/ent/notificationrecord"
 	"github.com/gitploy-io/gitploy/model/ent/predicate"
@@ -77,6 +78,26 @@ func (eu *EventUpdate) ClearDeploymentID() *EventUpdate {
 	return eu
 }
 
+// SetDeploymentStatusID sets the "deployment_status_id" field.
+func (eu *EventUpdate) SetDeploymentStatusID(i int) *EventUpdate {
+	eu.mutation.SetDeploymentStatusID(i)
+	return eu
+}
+
+// SetNillableDeploymentStatusID sets the "deployment_status_id" field if the given value is not nil.
+func (eu *EventUpdate) SetNillableDeploymentStatusID(i *int) *EventUpdate {
+	if i != nil {
+		eu.SetDeploymentStatusID(*i)
+	}
+	return eu
+}
+
+// ClearDeploymentStatusID clears the value of the "deployment_status_id" field.
+func (eu *EventUpdate) ClearDeploymentStatusID() *EventUpdate {
+	eu.mutation.ClearDeploymentStatusID()
+	return eu
+}
+
 // SetReviewID sets the "review_id" field.
 func (eu *EventUpdate) SetReviewID(i int) *EventUpdate {
 	eu.mutation.SetReviewID(i)
@@ -129,6 +150,11 @@ func (eu *EventUpdate) SetDeployment(d *Deployment) *EventUpdate {
 	return eu.SetDeploymentID(d.ID)
 }
 
+// SetDeploymentStatus sets the "deployment_status" edge to the DeploymentStatus entity.
+func (eu *EventUpdate) SetDeploymentStatus(d *DeploymentStatus) *EventUpdate {
+	return eu.SetDeploymentStatusID(d.ID)
+}
+
 // SetReview sets the "review" edge to the Review entity.
 func (eu *EventUpdate) SetReview(r *Review) *EventUpdate {
 	return eu.SetReviewID(r.ID)
@@ -161,6 +187,12 @@ func (eu *EventUpdate) Mutation() *EventMutation {
 // ClearDeployment clears the "deployment" edge to the Deployment entity.
 func (eu *EventUpdate) ClearDeployment() *EventUpdate {
 	eu.mutation.ClearDeployment()
+	return eu
+}
+
+// ClearDeploymentStatus clears the "deployment_status" edge to the DeploymentStatus entity.
+func (eu *EventUpdate) ClearDeploymentStatus() *EventUpdate {
+	eu.mutation.ClearDeploymentStatus()
 	return eu
 }
 
@@ -345,6 +377,41 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
+	if eu.mutation.DeploymentStatusCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   event.DeploymentStatusTable,
+			Columns: []string{event.DeploymentStatusColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt,
+					Column: deploymentstatus.FieldID,
+				},
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := eu.mutation.DeploymentStatusIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   event.DeploymentStatusTable,
+			Columns: []string{event.DeploymentStatusColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt,
+					Column: deploymentstatus.FieldID,
+				},
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
 	if eu.mutation.ReviewCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
@@ -480,6 +547,26 @@ func (euo *EventUpdateOne) ClearDeploymentID() *EventUpdateOne {
 	return euo
 }
 
+// SetDeploymentStatusID sets the "deployment_status_id" field.
+func (euo *EventUpdateOne) SetDeploymentStatusID(i int) *EventUpdateOne {
+	euo.mutation.SetDeploymentStatusID(i)
+	return euo
+}
+
+// SetNillableDeploymentStatusID sets the "deployment_status_id" field if the given value is not nil.
+func (euo *EventUpdateOne) SetNillableDeploymentStatusID(i *int) *EventUpdateOne {
+	if i != nil {
+		euo.SetDeploymentStatusID(*i)
+	}
+	return euo
+}
+
+// ClearDeploymentStatusID clears the value of the "deployment_status_id" field.
+func (euo *EventUpdateOne) ClearDeploymentStatusID() *EventUpdateOne {
+	euo.mutation.ClearDeploymentStatusID()
+	return euo
+}
+
 // SetReviewID sets the "review_id" field.
 func (euo *EventUpdateOne) SetReviewID(i int) *EventUpdateOne {
 	euo.mutation.SetReviewID(i)
@@ -532,6 +619,11 @@ func (euo *EventUpdateOne) SetDeployment(d *Deployment) *EventUpdateOne {
 	return euo.SetDeploymentID(d.ID)
 }
 
+// SetDeploymentStatus sets the "deployment_status" edge to the DeploymentStatus entity.
+func (euo *EventUpdateOne) SetDeploymentStatus(d *DeploymentStatus) *EventUpdateOne {
+	return euo.SetDeploymentStatusID(d.ID)
+}
+
 // SetReview sets the "review" edge to the Review entity.
 func (euo *EventUpdateOne) SetReview(r *Review) *EventUpdateOne {
 	return euo.SetReviewID(r.ID)
@@ -564,6 +656,12 @@ func (euo *EventUpdateOne) Mutation() *EventMutation {
 // ClearDeployment clears the "deployment" edge to the Deployment entity.
 func (euo *EventUpdateOne) ClearDeployment() *EventUpdateOne {
 	euo.mutation.ClearDeployment()
+	return euo
+}
+
+// ClearDeploymentStatus clears the "deployment_status" edge to the DeploymentStatus entity.
+func (euo *EventUpdateOne) ClearDeploymentStatus() *EventUpdateOne {
+	euo.mutation.ClearDeploymentStatus()
 	return euo
 }
 
@@ -764,6 +862,41 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (_node *Event, err error
 				IDSpec: &sqlgraph.FieldSpec{
 					Type:   field.TypeInt,
 					Column: deployment.FieldID,
+				},
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if euo.mutation.DeploymentStatusCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   event.DeploymentStatusTable,
+			Columns: []string{event.DeploymentStatusColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt,
+					Column: deploymentstatus.FieldID,
+				},
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := euo.mutation.DeploymentStatusIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   event.DeploymentStatusTable,
+			Columns: []string{event.DeploymentStatusColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt,
+					Column: deploymentstatus.FieldID,
 				},
 			},
 		}

--- a/model/ent/migrate/schema.go
+++ b/model/ent/migrate/schema.go
@@ -156,7 +156,7 @@ var (
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "deployment_id", Type: field.TypeInt},
-		{Name: "repo_id", Type: field.TypeInt64},
+		{Name: "repo_id", Type: field.TypeInt64, Nullable: true},
 	}
 	// DeploymentStatusTable holds the schema information for the "deployment_status" table.
 	DeploymentStatusTable = &schema.Table{

--- a/model/ent/migrate/schema.go
+++ b/model/ent/migrate/schema.go
@@ -174,11 +174,12 @@ var (
 	// EventsColumns holds the columns for the "events" table.
 	EventsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
-		{Name: "kind", Type: field.TypeEnum, Enums: []string{"deployment", "review", "approval"}},
+		{Name: "kind", Type: field.TypeEnum, Enums: []string{"deployment", "deployment_status", "review"}},
 		{Name: "type", Type: field.TypeEnum, Enums: []string{"created", "updated", "deleted"}},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "deleted_id", Type: field.TypeInt, Nullable: true},
 		{Name: "deployment_id", Type: field.TypeInt, Nullable: true},
+		{Name: "deployment_status_id", Type: field.TypeInt, Nullable: true},
 		{Name: "review_id", Type: field.TypeInt, Nullable: true},
 	}
 	// EventsTable holds the schema information for the "events" table.
@@ -194,8 +195,14 @@ var (
 				OnDelete:   schema.Cascade,
 			},
 			{
-				Symbol:     "events_reviews_event",
+				Symbol:     "events_deployment_status_event",
 				Columns:    []*schema.Column{EventsColumns[6]},
+				RefColumns: []*schema.Column{DeploymentStatusColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+			{
+				Symbol:     "events_reviews_event",
+				Columns:    []*schema.Column{EventsColumns[7]},
 				RefColumns: []*schema.Column{ReviewsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -422,7 +429,8 @@ func init() {
 	DeploymentStatisticsTable.ForeignKeys[0].RefTable = ReposTable
 	DeploymentStatusTable.ForeignKeys[0].RefTable = DeploymentsTable
 	EventsTable.ForeignKeys[0].RefTable = DeploymentsTable
-	EventsTable.ForeignKeys[1].RefTable = ReviewsTable
+	EventsTable.ForeignKeys[1].RefTable = DeploymentStatusTable
+	EventsTable.ForeignKeys[2].RefTable = ReviewsTable
 	LocksTable.ForeignKeys[0].RefTable = ReposTable
 	LocksTable.ForeignKeys[1].RefTable = UsersTable
 	NotificationRecordsTable.ForeignKeys[0].RefTable = EventsTable

--- a/model/ent/migrate/schema.go
+++ b/model/ent/migrate/schema.go
@@ -156,6 +156,7 @@ var (
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "deployment_id", Type: field.TypeInt},
+		{Name: "repo_id", Type: field.TypeInt64},
 	}
 	// DeploymentStatusTable holds the schema information for the "deployment_status" table.
 	DeploymentStatusTable = &schema.Table{
@@ -167,6 +168,12 @@ var (
 				Symbol:     "deployment_status_deployments_deployment_statuses",
 				Columns:    []*schema.Column{DeploymentStatusColumns[6]},
 				RefColumns: []*schema.Column{DeploymentsColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+			{
+				Symbol:     "deployment_status_repos_deployment_statuses",
+				Columns:    []*schema.Column{DeploymentStatusColumns[7]},
+				RefColumns: []*schema.Column{ReposColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 		},
@@ -428,6 +435,7 @@ func init() {
 	DeploymentsTable.ForeignKeys[1].RefTable = UsersTable
 	DeploymentStatisticsTable.ForeignKeys[0].RefTable = ReposTable
 	DeploymentStatusTable.ForeignKeys[0].RefTable = DeploymentsTable
+	DeploymentStatusTable.ForeignKeys[1].RefTable = ReposTable
 	EventsTable.ForeignKeys[0].RefTable = DeploymentsTable
 	EventsTable.ForeignKeys[1].RefTable = DeploymentStatusTable
 	EventsTable.ForeignKeys[2].RefTable = ReviewsTable

--- a/model/ent/migrate/schema.go
+++ b/model/ent/migrate/schema.go
@@ -181,11 +181,10 @@ var (
 	// EventsColumns holds the columns for the "events" table.
 	EventsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
-		{Name: "kind", Type: field.TypeEnum, Enums: []string{"deployment", "deployment_status", "review"}},
+		{Name: "kind", Type: field.TypeEnum, Enums: []string{"deployment_status", "review"}},
 		{Name: "type", Type: field.TypeEnum, Enums: []string{"created", "updated", "deleted"}},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "deleted_id", Type: field.TypeInt, Nullable: true},
-		{Name: "deployment_id", Type: field.TypeInt, Nullable: true},
 		{Name: "deployment_status_id", Type: field.TypeInt, Nullable: true},
 		{Name: "review_id", Type: field.TypeInt, Nullable: true},
 	}
@@ -196,20 +195,14 @@ var (
 		PrimaryKey: []*schema.Column{EventsColumns[0]},
 		ForeignKeys: []*schema.ForeignKey{
 			{
-				Symbol:     "events_deployments_event",
-				Columns:    []*schema.Column{EventsColumns[5]},
-				RefColumns: []*schema.Column{DeploymentsColumns[0]},
-				OnDelete:   schema.Cascade,
-			},
-			{
 				Symbol:     "events_deployment_status_event",
-				Columns:    []*schema.Column{EventsColumns[6]},
+				Columns:    []*schema.Column{EventsColumns[5]},
 				RefColumns: []*schema.Column{DeploymentStatusColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "events_reviews_event",
-				Columns:    []*schema.Column{EventsColumns[7]},
+				Columns:    []*schema.Column{EventsColumns[6]},
 				RefColumns: []*schema.Column{ReviewsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -436,9 +429,8 @@ func init() {
 	DeploymentStatisticsTable.ForeignKeys[0].RefTable = ReposTable
 	DeploymentStatusTable.ForeignKeys[0].RefTable = DeploymentsTable
 	DeploymentStatusTable.ForeignKeys[1].RefTable = ReposTable
-	EventsTable.ForeignKeys[0].RefTable = DeploymentsTable
-	EventsTable.ForeignKeys[1].RefTable = DeploymentStatusTable
-	EventsTable.ForeignKeys[2].RefTable = ReviewsTable
+	EventsTable.ForeignKeys[0].RefTable = DeploymentStatusTable
+	EventsTable.ForeignKeys[1].RefTable = ReviewsTable
 	LocksTable.ForeignKeys[0].RefTable = ReposTable
 	LocksTable.ForeignKeys[1].RefTable = UsersTable
 	NotificationRecordsTable.ForeignKeys[0].RefTable = EventsTable

--- a/model/ent/mutation.go
+++ b/model/ent/mutation.go
@@ -4026,9 +4026,22 @@ func (m *DeploymentStatusMutation) OldRepoID(ctx context.Context) (v int64, err 
 	return oldValue.RepoID, nil
 }
 
+// ClearRepoID clears the value of the "repo_id" field.
+func (m *DeploymentStatusMutation) ClearRepoID() {
+	m.repo = nil
+	m.clearedFields[deploymentstatus.FieldRepoID] = struct{}{}
+}
+
+// RepoIDCleared returns if the "repo_id" field was cleared in this mutation.
+func (m *DeploymentStatusMutation) RepoIDCleared() bool {
+	_, ok := m.clearedFields[deploymentstatus.FieldRepoID]
+	return ok
+}
+
 // ResetRepoID resets all changes to the "repo_id" field.
 func (m *DeploymentStatusMutation) ResetRepoID() {
 	m.repo = nil
+	delete(m.clearedFields, deploymentstatus.FieldRepoID)
 }
 
 // ClearDeployment clears the "deployment" edge to the Deployment entity.
@@ -4064,7 +4077,7 @@ func (m *DeploymentStatusMutation) ClearRepo() {
 
 // RepoCleared reports if the "repo" edge to the Repo entity was cleared.
 func (m *DeploymentStatusMutation) RepoCleared() bool {
-	return m.clearedrepo
+	return m.RepoIDCleared() || m.clearedrepo
 }
 
 // RepoIDs returns the "repo" edge IDs in the mutation.
@@ -4320,6 +4333,9 @@ func (m *DeploymentStatusMutation) ClearedFields() []string {
 	if m.FieldCleared(deploymentstatus.FieldLogURL) {
 		fields = append(fields, deploymentstatus.FieldLogURL)
 	}
+	if m.FieldCleared(deploymentstatus.FieldRepoID) {
+		fields = append(fields, deploymentstatus.FieldRepoID)
+	}
 	return fields
 }
 
@@ -4339,6 +4355,9 @@ func (m *DeploymentStatusMutation) ClearField(name string) error {
 		return nil
 	case deploymentstatus.FieldLogURL:
 		m.ClearLogURL()
+		return nil
+	case deploymentstatus.FieldRepoID:
+		m.ClearRepoID()
 		return nil
 	}
 	return fmt.Errorf("unknown DeploymentStatus nullable field %s", name)

--- a/model/ent/mutation.go
+++ b/model/ent/mutation.go
@@ -781,9 +781,6 @@ type DeploymentMutation struct {
 	deployment_statuses        map[int]struct{}
 	removeddeployment_statuses map[int]struct{}
 	cleareddeployment_statuses bool
-	event                      map[int]struct{}
-	removedevent               map[int]struct{}
-	clearedevent               bool
 	done                       bool
 	oldValue                   func(context.Context) (*Deployment, error)
 	predicates                 []predicate.Deployment
@@ -1799,60 +1796,6 @@ func (m *DeploymentMutation) ResetDeploymentStatuses() {
 	m.removeddeployment_statuses = nil
 }
 
-// AddEventIDs adds the "event" edge to the Event entity by ids.
-func (m *DeploymentMutation) AddEventIDs(ids ...int) {
-	if m.event == nil {
-		m.event = make(map[int]struct{})
-	}
-	for i := range ids {
-		m.event[ids[i]] = struct{}{}
-	}
-}
-
-// ClearEvent clears the "event" edge to the Event entity.
-func (m *DeploymentMutation) ClearEvent() {
-	m.clearedevent = true
-}
-
-// EventCleared reports if the "event" edge to the Event entity was cleared.
-func (m *DeploymentMutation) EventCleared() bool {
-	return m.clearedevent
-}
-
-// RemoveEventIDs removes the "event" edge to the Event entity by IDs.
-func (m *DeploymentMutation) RemoveEventIDs(ids ...int) {
-	if m.removedevent == nil {
-		m.removedevent = make(map[int]struct{})
-	}
-	for i := range ids {
-		delete(m.event, ids[i])
-		m.removedevent[ids[i]] = struct{}{}
-	}
-}
-
-// RemovedEvent returns the removed IDs of the "event" edge to the Event entity.
-func (m *DeploymentMutation) RemovedEventIDs() (ids []int) {
-	for id := range m.removedevent {
-		ids = append(ids, id)
-	}
-	return
-}
-
-// EventIDs returns the "event" edge IDs in the mutation.
-func (m *DeploymentMutation) EventIDs() (ids []int) {
-	for id := range m.event {
-		ids = append(ids, id)
-	}
-	return
-}
-
-// ResetEvent resets all changes to the "event" edge.
-func (m *DeploymentMutation) ResetEvent() {
-	m.event = nil
-	m.clearedevent = false
-	m.removedevent = nil
-}
-
 // Where appends a list predicates to the DeploymentMutation builder.
 func (m *DeploymentMutation) Where(ps ...predicate.Deployment) {
 	m.predicates = append(m.predicates, ps...)
@@ -2321,7 +2264,7 @@ func (m *DeploymentMutation) ResetField(name string) error {
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *DeploymentMutation) AddedEdges() []string {
-	edges := make([]string, 0, 5)
+	edges := make([]string, 0, 4)
 	if m.user != nil {
 		edges = append(edges, deployment.EdgeUser)
 	}
@@ -2333,9 +2276,6 @@ func (m *DeploymentMutation) AddedEdges() []string {
 	}
 	if m.deployment_statuses != nil {
 		edges = append(edges, deployment.EdgeDeploymentStatuses)
-	}
-	if m.event != nil {
-		edges = append(edges, deployment.EdgeEvent)
 	}
 	return edges
 }
@@ -2364,27 +2304,18 @@ func (m *DeploymentMutation) AddedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
-	case deployment.EdgeEvent:
-		ids := make([]ent.Value, 0, len(m.event))
-		for id := range m.event {
-			ids = append(ids, id)
-		}
-		return ids
 	}
 	return nil
 }
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *DeploymentMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 5)
+	edges := make([]string, 0, 4)
 	if m.removedreviews != nil {
 		edges = append(edges, deployment.EdgeReviews)
 	}
 	if m.removeddeployment_statuses != nil {
 		edges = append(edges, deployment.EdgeDeploymentStatuses)
-	}
-	if m.removedevent != nil {
-		edges = append(edges, deployment.EdgeEvent)
 	}
 	return edges
 }
@@ -2405,19 +2336,13 @@ func (m *DeploymentMutation) RemovedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
-	case deployment.EdgeEvent:
-		ids := make([]ent.Value, 0, len(m.removedevent))
-		for id := range m.removedevent {
-			ids = append(ids, id)
-		}
-		return ids
 	}
 	return nil
 }
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *DeploymentMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 5)
+	edges := make([]string, 0, 4)
 	if m.cleareduser {
 		edges = append(edges, deployment.EdgeUser)
 	}
@@ -2429,9 +2354,6 @@ func (m *DeploymentMutation) ClearedEdges() []string {
 	}
 	if m.cleareddeployment_statuses {
 		edges = append(edges, deployment.EdgeDeploymentStatuses)
-	}
-	if m.clearedevent {
-		edges = append(edges, deployment.EdgeEvent)
 	}
 	return edges
 }
@@ -2448,8 +2370,6 @@ func (m *DeploymentMutation) EdgeCleared(name string) bool {
 		return m.clearedreviews
 	case deployment.EdgeDeploymentStatuses:
 		return m.cleareddeployment_statuses
-	case deployment.EdgeEvent:
-		return m.clearedevent
 	}
 	return false
 }
@@ -2483,9 +2403,6 @@ func (m *DeploymentMutation) ResetEdge(name string) error {
 		return nil
 	case deployment.EdgeDeploymentStatuses:
 		m.ResetDeploymentStatuses()
-		return nil
-	case deployment.EdgeEvent:
-		m.ResetEvent()
 		return nil
 	}
 	return fmt.Errorf("unknown Deployment edge %s", name)
@@ -4524,8 +4441,6 @@ type EventMutation struct {
 	deleted_id                 *int
 	adddeleted_id              *int
 	clearedFields              map[string]struct{}
-	deployment                 *int
-	cleareddeployment          bool
 	deployment_status          *int
 	cleareddeployment_status   bool
 	review                     *int
@@ -4743,55 +4658,6 @@ func (m *EventMutation) ResetCreatedAt() {
 	m.created_at = nil
 }
 
-// SetDeploymentID sets the "deployment_id" field.
-func (m *EventMutation) SetDeploymentID(i int) {
-	m.deployment = &i
-}
-
-// DeploymentID returns the value of the "deployment_id" field in the mutation.
-func (m *EventMutation) DeploymentID() (r int, exists bool) {
-	v := m.deployment
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldDeploymentID returns the old "deployment_id" field's value of the Event entity.
-// If the Event object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *EventMutation) OldDeploymentID(ctx context.Context) (v int, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldDeploymentID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldDeploymentID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldDeploymentID: %w", err)
-	}
-	return oldValue.DeploymentID, nil
-}
-
-// ClearDeploymentID clears the value of the "deployment_id" field.
-func (m *EventMutation) ClearDeploymentID() {
-	m.deployment = nil
-	m.clearedFields[event.FieldDeploymentID] = struct{}{}
-}
-
-// DeploymentIDCleared returns if the "deployment_id" field was cleared in this mutation.
-func (m *EventMutation) DeploymentIDCleared() bool {
-	_, ok := m.clearedFields[event.FieldDeploymentID]
-	return ok
-}
-
-// ResetDeploymentID resets all changes to the "deployment_id" field.
-func (m *EventMutation) ResetDeploymentID() {
-	m.deployment = nil
-	delete(m.clearedFields, event.FieldDeploymentID)
-}
-
 // SetDeploymentStatusID sets the "deployment_status_id" field.
 func (m *EventMutation) SetDeploymentStatusID(i int) {
 	m.deployment_status = &i
@@ -4960,32 +4826,6 @@ func (m *EventMutation) ResetDeletedID() {
 	delete(m.clearedFields, event.FieldDeletedID)
 }
 
-// ClearDeployment clears the "deployment" edge to the Deployment entity.
-func (m *EventMutation) ClearDeployment() {
-	m.cleareddeployment = true
-}
-
-// DeploymentCleared reports if the "deployment" edge to the Deployment entity was cleared.
-func (m *EventMutation) DeploymentCleared() bool {
-	return m.DeploymentIDCleared() || m.cleareddeployment
-}
-
-// DeploymentIDs returns the "deployment" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// DeploymentID instead. It exists only for internal usage by the builders.
-func (m *EventMutation) DeploymentIDs() (ids []int) {
-	if id := m.deployment; id != nil {
-		ids = append(ids, *id)
-	}
-	return
-}
-
-// ResetDeployment resets all changes to the "deployment" edge.
-func (m *EventMutation) ResetDeployment() {
-	m.deployment = nil
-	m.cleareddeployment = false
-}
-
 // ClearDeploymentStatus clears the "deployment_status" edge to the DeploymentStatus entity.
 func (m *EventMutation) ClearDeploymentStatus() {
 	m.cleareddeployment_status = true
@@ -5096,7 +4936,7 @@ func (m *EventMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *EventMutation) Fields() []string {
-	fields := make([]string, 0, 7)
+	fields := make([]string, 0, 6)
 	if m.kind != nil {
 		fields = append(fields, event.FieldKind)
 	}
@@ -5105,9 +4945,6 @@ func (m *EventMutation) Fields() []string {
 	}
 	if m.created_at != nil {
 		fields = append(fields, event.FieldCreatedAt)
-	}
-	if m.deployment != nil {
-		fields = append(fields, event.FieldDeploymentID)
 	}
 	if m.deployment_status != nil {
 		fields = append(fields, event.FieldDeploymentStatusID)
@@ -5132,8 +4969,6 @@ func (m *EventMutation) Field(name string) (ent.Value, bool) {
 		return m.GetType()
 	case event.FieldCreatedAt:
 		return m.CreatedAt()
-	case event.FieldDeploymentID:
-		return m.DeploymentID()
 	case event.FieldDeploymentStatusID:
 		return m.DeploymentStatusID()
 	case event.FieldReviewID:
@@ -5155,8 +4990,6 @@ func (m *EventMutation) OldField(ctx context.Context, name string) (ent.Value, e
 		return m.OldType(ctx)
 	case event.FieldCreatedAt:
 		return m.OldCreatedAt(ctx)
-	case event.FieldDeploymentID:
-		return m.OldDeploymentID(ctx)
 	case event.FieldDeploymentStatusID:
 		return m.OldDeploymentStatusID(ctx)
 	case event.FieldReviewID:
@@ -5192,13 +5025,6 @@ func (m *EventMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetCreatedAt(v)
-		return nil
-	case event.FieldDeploymentID:
-		v, ok := value.(int)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetDeploymentID(v)
 		return nil
 	case event.FieldDeploymentStatusID:
 		v, ok := value.(int)
@@ -5266,9 +5092,6 @@ func (m *EventMutation) AddField(name string, value ent.Value) error {
 // mutation.
 func (m *EventMutation) ClearedFields() []string {
 	var fields []string
-	if m.FieldCleared(event.FieldDeploymentID) {
-		fields = append(fields, event.FieldDeploymentID)
-	}
 	if m.FieldCleared(event.FieldDeploymentStatusID) {
 		fields = append(fields, event.FieldDeploymentStatusID)
 	}
@@ -5292,9 +5115,6 @@ func (m *EventMutation) FieldCleared(name string) bool {
 // error if the field is not defined in the schema.
 func (m *EventMutation) ClearField(name string) error {
 	switch name {
-	case event.FieldDeploymentID:
-		m.ClearDeploymentID()
-		return nil
 	case event.FieldDeploymentStatusID:
 		m.ClearDeploymentStatusID()
 		return nil
@@ -5321,9 +5141,6 @@ func (m *EventMutation) ResetField(name string) error {
 	case event.FieldCreatedAt:
 		m.ResetCreatedAt()
 		return nil
-	case event.FieldDeploymentID:
-		m.ResetDeploymentID()
-		return nil
 	case event.FieldDeploymentStatusID:
 		m.ResetDeploymentStatusID()
 		return nil
@@ -5339,10 +5156,7 @@ func (m *EventMutation) ResetField(name string) error {
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *EventMutation) AddedEdges() []string {
-	edges := make([]string, 0, 4)
-	if m.deployment != nil {
-		edges = append(edges, event.EdgeDeployment)
-	}
+	edges := make([]string, 0, 3)
 	if m.deployment_status != nil {
 		edges = append(edges, event.EdgeDeploymentStatus)
 	}
@@ -5359,10 +5173,6 @@ func (m *EventMutation) AddedEdges() []string {
 // name in this mutation.
 func (m *EventMutation) AddedIDs(name string) []ent.Value {
 	switch name {
-	case event.EdgeDeployment:
-		if id := m.deployment; id != nil {
-			return []ent.Value{*id}
-		}
 	case event.EdgeDeploymentStatus:
 		if id := m.deployment_status; id != nil {
 			return []ent.Value{*id}
@@ -5381,7 +5191,7 @@ func (m *EventMutation) AddedIDs(name string) []ent.Value {
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *EventMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 4)
+	edges := make([]string, 0, 3)
 	return edges
 }
 
@@ -5395,10 +5205,7 @@ func (m *EventMutation) RemovedIDs(name string) []ent.Value {
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *EventMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 4)
-	if m.cleareddeployment {
-		edges = append(edges, event.EdgeDeployment)
-	}
+	edges := make([]string, 0, 3)
 	if m.cleareddeployment_status {
 		edges = append(edges, event.EdgeDeploymentStatus)
 	}
@@ -5415,8 +5222,6 @@ func (m *EventMutation) ClearedEdges() []string {
 // was cleared in this mutation.
 func (m *EventMutation) EdgeCleared(name string) bool {
 	switch name {
-	case event.EdgeDeployment:
-		return m.cleareddeployment
 	case event.EdgeDeploymentStatus:
 		return m.cleareddeployment_status
 	case event.EdgeReview:
@@ -5431,9 +5236,6 @@ func (m *EventMutation) EdgeCleared(name string) bool {
 // if that edge is not defined in the schema.
 func (m *EventMutation) ClearEdge(name string) error {
 	switch name {
-	case event.EdgeDeployment:
-		m.ClearDeployment()
-		return nil
 	case event.EdgeDeploymentStatus:
 		m.ClearDeploymentStatus()
 		return nil
@@ -5451,9 +5253,6 @@ func (m *EventMutation) ClearEdge(name string) error {
 // It returns an error if the edge is not defined in the schema.
 func (m *EventMutation) ResetEdge(name string) error {
 	switch name {
-	case event.EdgeDeployment:
-		m.ResetDeployment()
-		return nil
 	case event.EdgeDeploymentStatus:
 		m.ResetDeploymentStatus()
 		return nil

--- a/model/ent/mutation.go
+++ b/model/ent/mutation.go
@@ -3645,6 +3645,8 @@ type DeploymentStatusMutation struct {
 	clearedFields     map[string]struct{}
 	deployment        *int
 	cleareddeployment bool
+	repo              *int64
+	clearedrepo       bool
 	event             map[int]struct{}
 	removedevent      map[int]struct{}
 	clearedevent      bool
@@ -3993,6 +3995,42 @@ func (m *DeploymentStatusMutation) ResetDeploymentID() {
 	m.deployment = nil
 }
 
+// SetRepoID sets the "repo_id" field.
+func (m *DeploymentStatusMutation) SetRepoID(i int64) {
+	m.repo = &i
+}
+
+// RepoID returns the value of the "repo_id" field in the mutation.
+func (m *DeploymentStatusMutation) RepoID() (r int64, exists bool) {
+	v := m.repo
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldRepoID returns the old "repo_id" field's value of the DeploymentStatus entity.
+// If the DeploymentStatus object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *DeploymentStatusMutation) OldRepoID(ctx context.Context) (v int64, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldRepoID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldRepoID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldRepoID: %w", err)
+	}
+	return oldValue.RepoID, nil
+}
+
+// ResetRepoID resets all changes to the "repo_id" field.
+func (m *DeploymentStatusMutation) ResetRepoID() {
+	m.repo = nil
+}
+
 // ClearDeployment clears the "deployment" edge to the Deployment entity.
 func (m *DeploymentStatusMutation) ClearDeployment() {
 	m.cleareddeployment = true
@@ -4017,6 +4055,32 @@ func (m *DeploymentStatusMutation) DeploymentIDs() (ids []int) {
 func (m *DeploymentStatusMutation) ResetDeployment() {
 	m.deployment = nil
 	m.cleareddeployment = false
+}
+
+// ClearRepo clears the "repo" edge to the Repo entity.
+func (m *DeploymentStatusMutation) ClearRepo() {
+	m.clearedrepo = true
+}
+
+// RepoCleared reports if the "repo" edge to the Repo entity was cleared.
+func (m *DeploymentStatusMutation) RepoCleared() bool {
+	return m.clearedrepo
+}
+
+// RepoIDs returns the "repo" edge IDs in the mutation.
+// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
+// RepoID instead. It exists only for internal usage by the builders.
+func (m *DeploymentStatusMutation) RepoIDs() (ids []int64) {
+	if id := m.repo; id != nil {
+		ids = append(ids, *id)
+	}
+	return
+}
+
+// ResetRepo resets all changes to the "repo" edge.
+func (m *DeploymentStatusMutation) ResetRepo() {
+	m.repo = nil
+	m.clearedrepo = false
 }
 
 // AddEventIDs adds the "event" edge to the Event entity by ids.
@@ -4092,7 +4156,7 @@ func (m *DeploymentStatusMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *DeploymentStatusMutation) Fields() []string {
-	fields := make([]string, 0, 6)
+	fields := make([]string, 0, 7)
 	if m.status != nil {
 		fields = append(fields, deploymentstatus.FieldStatus)
 	}
@@ -4110,6 +4174,9 @@ func (m *DeploymentStatusMutation) Fields() []string {
 	}
 	if m.deployment != nil {
 		fields = append(fields, deploymentstatus.FieldDeploymentID)
+	}
+	if m.repo != nil {
+		fields = append(fields, deploymentstatus.FieldRepoID)
 	}
 	return fields
 }
@@ -4131,6 +4198,8 @@ func (m *DeploymentStatusMutation) Field(name string) (ent.Value, bool) {
 		return m.UpdatedAt()
 	case deploymentstatus.FieldDeploymentID:
 		return m.DeploymentID()
+	case deploymentstatus.FieldRepoID:
+		return m.RepoID()
 	}
 	return nil, false
 }
@@ -4152,6 +4221,8 @@ func (m *DeploymentStatusMutation) OldField(ctx context.Context, name string) (e
 		return m.OldUpdatedAt(ctx)
 	case deploymentstatus.FieldDeploymentID:
 		return m.OldDeploymentID(ctx)
+	case deploymentstatus.FieldRepoID:
+		return m.OldRepoID(ctx)
 	}
 	return nil, fmt.Errorf("unknown DeploymentStatus field %s", name)
 }
@@ -4202,6 +4273,13 @@ func (m *DeploymentStatusMutation) SetField(name string, value ent.Value) error 
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetDeploymentID(v)
+		return nil
+	case deploymentstatus.FieldRepoID:
+		v, ok := value.(int64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetRepoID(v)
 		return nil
 	}
 	return fmt.Errorf("unknown DeploymentStatus field %s", name)
@@ -4288,15 +4366,21 @@ func (m *DeploymentStatusMutation) ResetField(name string) error {
 	case deploymentstatus.FieldDeploymentID:
 		m.ResetDeploymentID()
 		return nil
+	case deploymentstatus.FieldRepoID:
+		m.ResetRepoID()
+		return nil
 	}
 	return fmt.Errorf("unknown DeploymentStatus field %s", name)
 }
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *DeploymentStatusMutation) AddedEdges() []string {
-	edges := make([]string, 0, 2)
+	edges := make([]string, 0, 3)
 	if m.deployment != nil {
 		edges = append(edges, deploymentstatus.EdgeDeployment)
+	}
+	if m.repo != nil {
+		edges = append(edges, deploymentstatus.EdgeRepo)
 	}
 	if m.event != nil {
 		edges = append(edges, deploymentstatus.EdgeEvent)
@@ -4312,6 +4396,10 @@ func (m *DeploymentStatusMutation) AddedIDs(name string) []ent.Value {
 		if id := m.deployment; id != nil {
 			return []ent.Value{*id}
 		}
+	case deploymentstatus.EdgeRepo:
+		if id := m.repo; id != nil {
+			return []ent.Value{*id}
+		}
 	case deploymentstatus.EdgeEvent:
 		ids := make([]ent.Value, 0, len(m.event))
 		for id := range m.event {
@@ -4324,7 +4412,7 @@ func (m *DeploymentStatusMutation) AddedIDs(name string) []ent.Value {
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *DeploymentStatusMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 2)
+	edges := make([]string, 0, 3)
 	if m.removedevent != nil {
 		edges = append(edges, deploymentstatus.EdgeEvent)
 	}
@@ -4347,9 +4435,12 @@ func (m *DeploymentStatusMutation) RemovedIDs(name string) []ent.Value {
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *DeploymentStatusMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 2)
+	edges := make([]string, 0, 3)
 	if m.cleareddeployment {
 		edges = append(edges, deploymentstatus.EdgeDeployment)
+	}
+	if m.clearedrepo {
+		edges = append(edges, deploymentstatus.EdgeRepo)
 	}
 	if m.clearedevent {
 		edges = append(edges, deploymentstatus.EdgeEvent)
@@ -4363,6 +4454,8 @@ func (m *DeploymentStatusMutation) EdgeCleared(name string) bool {
 	switch name {
 	case deploymentstatus.EdgeDeployment:
 		return m.cleareddeployment
+	case deploymentstatus.EdgeRepo:
+		return m.clearedrepo
 	case deploymentstatus.EdgeEvent:
 		return m.clearedevent
 	}
@@ -4376,6 +4469,9 @@ func (m *DeploymentStatusMutation) ClearEdge(name string) error {
 	case deploymentstatus.EdgeDeployment:
 		m.ClearDeployment()
 		return nil
+	case deploymentstatus.EdgeRepo:
+		m.ClearRepo()
+		return nil
 	}
 	return fmt.Errorf("unknown DeploymentStatus unique edge %s", name)
 }
@@ -4386,6 +4482,9 @@ func (m *DeploymentStatusMutation) ResetEdge(name string) error {
 	switch name {
 	case deploymentstatus.EdgeDeployment:
 		m.ResetDeployment()
+		return nil
+	case deploymentstatus.EdgeRepo:
+		m.ResetRepo()
 		return nil
 	case deploymentstatus.EdgeEvent:
 		m.ResetEvent()
@@ -7099,6 +7198,9 @@ type RepoMutation struct {
 	deployments                  map[int]struct{}
 	removeddeployments           map[int]struct{}
 	cleareddeployments           bool
+	deployment_statuses          map[int]struct{}
+	removeddeployment_statuses   map[int]struct{}
+	cleareddeployment_statuses   bool
 	locks                        map[int]struct{}
 	removedlocks                 map[int]struct{}
 	clearedlocks                 bool
@@ -7744,6 +7846,60 @@ func (m *RepoMutation) ResetDeployments() {
 	m.removeddeployments = nil
 }
 
+// AddDeploymentStatusIDs adds the "deployment_statuses" edge to the DeploymentStatus entity by ids.
+func (m *RepoMutation) AddDeploymentStatusIDs(ids ...int) {
+	if m.deployment_statuses == nil {
+		m.deployment_statuses = make(map[int]struct{})
+	}
+	for i := range ids {
+		m.deployment_statuses[ids[i]] = struct{}{}
+	}
+}
+
+// ClearDeploymentStatuses clears the "deployment_statuses" edge to the DeploymentStatus entity.
+func (m *RepoMutation) ClearDeploymentStatuses() {
+	m.cleareddeployment_statuses = true
+}
+
+// DeploymentStatusesCleared reports if the "deployment_statuses" edge to the DeploymentStatus entity was cleared.
+func (m *RepoMutation) DeploymentStatusesCleared() bool {
+	return m.cleareddeployment_statuses
+}
+
+// RemoveDeploymentStatusIDs removes the "deployment_statuses" edge to the DeploymentStatus entity by IDs.
+func (m *RepoMutation) RemoveDeploymentStatusIDs(ids ...int) {
+	if m.removeddeployment_statuses == nil {
+		m.removeddeployment_statuses = make(map[int]struct{})
+	}
+	for i := range ids {
+		delete(m.deployment_statuses, ids[i])
+		m.removeddeployment_statuses[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedDeploymentStatuses returns the removed IDs of the "deployment_statuses" edge to the DeploymentStatus entity.
+func (m *RepoMutation) RemovedDeploymentStatusesIDs() (ids []int) {
+	for id := range m.removeddeployment_statuses {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// DeploymentStatusesIDs returns the "deployment_statuses" edge IDs in the mutation.
+func (m *RepoMutation) DeploymentStatusesIDs() (ids []int) {
+	for id := range m.deployment_statuses {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetDeploymentStatuses resets all changes to the "deployment_statuses" edge.
+func (m *RepoMutation) ResetDeploymentStatuses() {
+	m.deployment_statuses = nil
+	m.cleareddeployment_statuses = false
+	m.removeddeployment_statuses = nil
+}
+
 // AddLockIDs adds the "locks" edge to the Lock entity by ids.
 func (m *RepoMutation) AddLockIDs(ids ...int) {
 	if m.locks == nil {
@@ -8185,12 +8341,15 @@ func (m *RepoMutation) ResetField(name string) error {
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *RepoMutation) AddedEdges() []string {
-	edges := make([]string, 0, 5)
+	edges := make([]string, 0, 6)
 	if m.perms != nil {
 		edges = append(edges, repo.EdgePerms)
 	}
 	if m.deployments != nil {
 		edges = append(edges, repo.EdgeDeployments)
+	}
+	if m.deployment_statuses != nil {
+		edges = append(edges, repo.EdgeDeploymentStatuses)
 	}
 	if m.locks != nil {
 		edges = append(edges, repo.EdgeLocks)
@@ -8220,6 +8379,12 @@ func (m *RepoMutation) AddedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
+	case repo.EdgeDeploymentStatuses:
+		ids := make([]ent.Value, 0, len(m.deployment_statuses))
+		for id := range m.deployment_statuses {
+			ids = append(ids, id)
+		}
+		return ids
 	case repo.EdgeLocks:
 		ids := make([]ent.Value, 0, len(m.locks))
 		for id := range m.locks {
@@ -8242,12 +8407,15 @@ func (m *RepoMutation) AddedIDs(name string) []ent.Value {
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *RepoMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 5)
+	edges := make([]string, 0, 6)
 	if m.removedperms != nil {
 		edges = append(edges, repo.EdgePerms)
 	}
 	if m.removeddeployments != nil {
 		edges = append(edges, repo.EdgeDeployments)
+	}
+	if m.removeddeployment_statuses != nil {
+		edges = append(edges, repo.EdgeDeploymentStatuses)
 	}
 	if m.removedlocks != nil {
 		edges = append(edges, repo.EdgeLocks)
@@ -8274,6 +8442,12 @@ func (m *RepoMutation) RemovedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
+	case repo.EdgeDeploymentStatuses:
+		ids := make([]ent.Value, 0, len(m.removeddeployment_statuses))
+		for id := range m.removeddeployment_statuses {
+			ids = append(ids, id)
+		}
+		return ids
 	case repo.EdgeLocks:
 		ids := make([]ent.Value, 0, len(m.removedlocks))
 		for id := range m.removedlocks {
@@ -8292,12 +8466,15 @@ func (m *RepoMutation) RemovedIDs(name string) []ent.Value {
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *RepoMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 5)
+	edges := make([]string, 0, 6)
 	if m.clearedperms {
 		edges = append(edges, repo.EdgePerms)
 	}
 	if m.cleareddeployments {
 		edges = append(edges, repo.EdgeDeployments)
+	}
+	if m.cleareddeployment_statuses {
+		edges = append(edges, repo.EdgeDeploymentStatuses)
 	}
 	if m.clearedlocks {
 		edges = append(edges, repo.EdgeLocks)
@@ -8319,6 +8496,8 @@ func (m *RepoMutation) EdgeCleared(name string) bool {
 		return m.clearedperms
 	case repo.EdgeDeployments:
 		return m.cleareddeployments
+	case repo.EdgeDeploymentStatuses:
+		return m.cleareddeployment_statuses
 	case repo.EdgeLocks:
 		return m.clearedlocks
 	case repo.EdgeDeploymentStatistics:
@@ -8349,6 +8528,9 @@ func (m *RepoMutation) ResetEdge(name string) error {
 		return nil
 	case repo.EdgeDeployments:
 		m.ResetDeployments()
+		return nil
+	case repo.EdgeDeploymentStatuses:
+		m.ResetDeploymentStatuses()
 		return nil
 	case repo.EdgeLocks:
 		m.ResetLocks()

--- a/model/ent/repo.go
+++ b/model/ent/repo.go
@@ -48,6 +48,8 @@ type RepoEdges struct {
 	Perms []*Perm `json:"perms,omitempty"`
 	// Deployments holds the value of the deployments edge.
 	Deployments []*Deployment `json:"deployments,omitempty"`
+	// DeploymentStatuses holds the value of the deployment_statuses edge.
+	DeploymentStatuses []*DeploymentStatus `json:"deployment_statuses,omitempty"`
 	// Locks holds the value of the locks edge.
 	Locks []*Lock `json:"locks,omitempty"`
 	// DeploymentStatistics holds the value of the deployment_statistics edge.
@@ -56,7 +58,7 @@ type RepoEdges struct {
 	Owner *User `json:"owner,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [5]bool
+	loadedTypes [6]bool
 }
 
 // PermsOrErr returns the Perms value or an error if the edge
@@ -77,10 +79,19 @@ func (e RepoEdges) DeploymentsOrErr() ([]*Deployment, error) {
 	return nil, &NotLoadedError{edge: "deployments"}
 }
 
+// DeploymentStatusesOrErr returns the DeploymentStatuses value or an error if the edge
+// was not loaded in eager-loading.
+func (e RepoEdges) DeploymentStatusesOrErr() ([]*DeploymentStatus, error) {
+	if e.loadedTypes[2] {
+		return e.DeploymentStatuses, nil
+	}
+	return nil, &NotLoadedError{edge: "deployment_statuses"}
+}
+
 // LocksOrErr returns the Locks value or an error if the edge
 // was not loaded in eager-loading.
 func (e RepoEdges) LocksOrErr() ([]*Lock, error) {
-	if e.loadedTypes[2] {
+	if e.loadedTypes[3] {
 		return e.Locks, nil
 	}
 	return nil, &NotLoadedError{edge: "locks"}
@@ -89,7 +100,7 @@ func (e RepoEdges) LocksOrErr() ([]*Lock, error) {
 // DeploymentStatisticsOrErr returns the DeploymentStatistics value or an error if the edge
 // was not loaded in eager-loading.
 func (e RepoEdges) DeploymentStatisticsOrErr() ([]*DeploymentStatistics, error) {
-	if e.loadedTypes[3] {
+	if e.loadedTypes[4] {
 		return e.DeploymentStatistics, nil
 	}
 	return nil, &NotLoadedError{edge: "deployment_statistics"}
@@ -98,7 +109,7 @@ func (e RepoEdges) DeploymentStatisticsOrErr() ([]*DeploymentStatistics, error) 
 // OwnerOrErr returns the Owner value or an error if the edge
 // was not loaded in eager-loading, or loaded but was not found.
 func (e RepoEdges) OwnerOrErr() (*User, error) {
-	if e.loadedTypes[4] {
+	if e.loadedTypes[5] {
 		if e.Owner == nil {
 			// The edge owner was loaded in eager-loading,
 			// but was not found.
@@ -216,6 +227,11 @@ func (r *Repo) QueryPerms() *PermQuery {
 // QueryDeployments queries the "deployments" edge of the Repo entity.
 func (r *Repo) QueryDeployments() *DeploymentQuery {
 	return (&RepoClient{config: r.config}).QueryDeployments(r)
+}
+
+// QueryDeploymentStatuses queries the "deployment_statuses" edge of the Repo entity.
+func (r *Repo) QueryDeploymentStatuses() *DeploymentStatusQuery {
+	return (&RepoClient{config: r.config}).QueryDeploymentStatuses(r)
 }
 
 // QueryLocks queries the "locks" edge of the Repo entity.

--- a/model/ent/repo/repo.go
+++ b/model/ent/repo/repo.go
@@ -35,6 +35,8 @@ const (
 	EdgePerms = "perms"
 	// EdgeDeployments holds the string denoting the deployments edge name in mutations.
 	EdgeDeployments = "deployments"
+	// EdgeDeploymentStatuses holds the string denoting the deployment_statuses edge name in mutations.
+	EdgeDeploymentStatuses = "deployment_statuses"
 	// EdgeLocks holds the string denoting the locks edge name in mutations.
 	EdgeLocks = "locks"
 	// EdgeDeploymentStatistics holds the string denoting the deployment_statistics edge name in mutations.
@@ -57,6 +59,13 @@ const (
 	DeploymentsInverseTable = "deployments"
 	// DeploymentsColumn is the table column denoting the deployments relation/edge.
 	DeploymentsColumn = "repo_id"
+	// DeploymentStatusesTable is the table that holds the deployment_statuses relation/edge.
+	DeploymentStatusesTable = "deployment_status"
+	// DeploymentStatusesInverseTable is the table name for the DeploymentStatus entity.
+	// It exists in this package in order to avoid circular dependency with the "deploymentstatus" package.
+	DeploymentStatusesInverseTable = "deployment_status"
+	// DeploymentStatusesColumn is the table column denoting the deployment_statuses relation/edge.
+	DeploymentStatusesColumn = "repo_id"
 	// LocksTable is the table that holds the locks relation/edge.
 	LocksTable = "locks"
 	// LocksInverseTable is the table name for the Lock entity.

--- a/model/ent/repo/where.go
+++ b/model/ent/repo/where.go
@@ -1071,6 +1071,34 @@ func HasDeploymentsWith(preds ...predicate.Deployment) predicate.Repo {
 	})
 }
 
+// HasDeploymentStatuses applies the HasEdge predicate on the "deployment_statuses" edge.
+func HasDeploymentStatuses() predicate.Repo {
+	return predicate.Repo(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.To(DeploymentStatusesTable, FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, DeploymentStatusesTable, DeploymentStatusesColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasDeploymentStatusesWith applies the HasEdge predicate on the "deployment_statuses" edge with a given conditions (other predicates).
+func HasDeploymentStatusesWith(preds ...predicate.DeploymentStatus) predicate.Repo {
+	return predicate.Repo(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.To(DeploymentStatusesInverseTable, FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, DeploymentStatusesTable, DeploymentStatusesColumn),
+		)
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
 // HasLocks applies the HasEdge predicate on the "locks" edge.
 func HasLocks() predicate.Repo {
 	return predicate.Repo(func(s *sql.Selector) {

--- a/model/ent/repo_create.go
+++ b/model/ent/repo_create.go
@@ -12,6 +12,7 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/gitploy-io/gitploy/model/ent/deployment"
 	"github.com/gitploy-io/gitploy/model/ent/deploymentstatistics"
+	"github.com/gitploy-io/gitploy/model/ent/deploymentstatus"
 	"github.com/gitploy-io/gitploy/model/ent/lock"
 	"github.com/gitploy-io/gitploy/model/ent/perm"
 	"github.com/gitploy-io/gitploy/model/ent/repo"
@@ -175,6 +176,21 @@ func (rc *RepoCreate) AddDeployments(d ...*Deployment) *RepoCreate {
 		ids[i] = d[i].ID
 	}
 	return rc.AddDeploymentIDs(ids...)
+}
+
+// AddDeploymentStatusIDs adds the "deployment_statuses" edge to the DeploymentStatus entity by IDs.
+func (rc *RepoCreate) AddDeploymentStatusIDs(ids ...int) *RepoCreate {
+	rc.mutation.AddDeploymentStatusIDs(ids...)
+	return rc
+}
+
+// AddDeploymentStatuses adds the "deployment_statuses" edges to the DeploymentStatus entity.
+func (rc *RepoCreate) AddDeploymentStatuses(d ...*DeploymentStatus) *RepoCreate {
+	ids := make([]int, len(d))
+	for i := range d {
+		ids[i] = d[i].ID
+	}
+	return rc.AddDeploymentStatusIDs(ids...)
 }
 
 // AddLockIDs adds the "locks" edge to the Lock entity by IDs.
@@ -463,6 +479,25 @@ func (rc *RepoCreate) createSpec() (*Repo, *sqlgraph.CreateSpec) {
 				IDSpec: &sqlgraph.FieldSpec{
 					Type:   field.TypeInt,
 					Column: deployment.FieldID,
+				},
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := rc.mutation.DeploymentStatusesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   repo.DeploymentStatusesTable,
+			Columns: []string{repo.DeploymentStatusesColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt,
+					Column: deploymentstatus.FieldID,
 				},
 			},
 		}

--- a/model/ent/repo_update.go
+++ b/model/ent/repo_update.go
@@ -13,6 +13,7 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/gitploy-io/gitploy/model/ent/deployment"
 	"github.com/gitploy-io/gitploy/model/ent/deploymentstatistics"
+	"github.com/gitploy-io/gitploy/model/ent/deploymentstatus"
 	"github.com/gitploy-io/gitploy/model/ent/lock"
 	"github.com/gitploy-io/gitploy/model/ent/perm"
 	"github.com/gitploy-io/gitploy/model/ent/predicate"
@@ -196,6 +197,21 @@ func (ru *RepoUpdate) AddDeployments(d ...*Deployment) *RepoUpdate {
 	return ru.AddDeploymentIDs(ids...)
 }
 
+// AddDeploymentStatusIDs adds the "deployment_statuses" edge to the DeploymentStatus entity by IDs.
+func (ru *RepoUpdate) AddDeploymentStatusIDs(ids ...int) *RepoUpdate {
+	ru.mutation.AddDeploymentStatusIDs(ids...)
+	return ru
+}
+
+// AddDeploymentStatuses adds the "deployment_statuses" edges to the DeploymentStatus entity.
+func (ru *RepoUpdate) AddDeploymentStatuses(d ...*DeploymentStatus) *RepoUpdate {
+	ids := make([]int, len(d))
+	for i := range d {
+		ids[i] = d[i].ID
+	}
+	return ru.AddDeploymentStatusIDs(ids...)
+}
+
 // AddLockIDs adds the "locks" edge to the Lock entity by IDs.
 func (ru *RepoUpdate) AddLockIDs(ids ...int) *RepoUpdate {
 	ru.mutation.AddLockIDs(ids...)
@@ -276,6 +292,27 @@ func (ru *RepoUpdate) RemoveDeployments(d ...*Deployment) *RepoUpdate {
 		ids[i] = d[i].ID
 	}
 	return ru.RemoveDeploymentIDs(ids...)
+}
+
+// ClearDeploymentStatuses clears all "deployment_statuses" edges to the DeploymentStatus entity.
+func (ru *RepoUpdate) ClearDeploymentStatuses() *RepoUpdate {
+	ru.mutation.ClearDeploymentStatuses()
+	return ru
+}
+
+// RemoveDeploymentStatusIDs removes the "deployment_statuses" edge to DeploymentStatus entities by IDs.
+func (ru *RepoUpdate) RemoveDeploymentStatusIDs(ids ...int) *RepoUpdate {
+	ru.mutation.RemoveDeploymentStatusIDs(ids...)
+	return ru
+}
+
+// RemoveDeploymentStatuses removes "deployment_statuses" edges to DeploymentStatus entities.
+func (ru *RepoUpdate) RemoveDeploymentStatuses(d ...*DeploymentStatus) *RepoUpdate {
+	ids := make([]int, len(d))
+	for i := range d {
+		ids[i] = d[i].ID
+	}
+	return ru.RemoveDeploymentStatusIDs(ids...)
 }
 
 // ClearLocks clears all "locks" edges to the Lock entity.
@@ -589,6 +626,60 @@ func (ru *RepoUpdate) sqlSave(ctx context.Context) (n int, err error) {
 				IDSpec: &sqlgraph.FieldSpec{
 					Type:   field.TypeInt,
 					Column: deployment.FieldID,
+				},
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if ru.mutation.DeploymentStatusesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   repo.DeploymentStatusesTable,
+			Columns: []string{repo.DeploymentStatusesColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt,
+					Column: deploymentstatus.FieldID,
+				},
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ru.mutation.RemovedDeploymentStatusesIDs(); len(nodes) > 0 && !ru.mutation.DeploymentStatusesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   repo.DeploymentStatusesTable,
+			Columns: []string{repo.DeploymentStatusesColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt,
+					Column: deploymentstatus.FieldID,
+				},
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ru.mutation.DeploymentStatusesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   repo.DeploymentStatusesTable,
+			Columns: []string{repo.DeploymentStatusesColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt,
+					Column: deploymentstatus.FieldID,
 				},
 			},
 		}
@@ -922,6 +1013,21 @@ func (ruo *RepoUpdateOne) AddDeployments(d ...*Deployment) *RepoUpdateOne {
 	return ruo.AddDeploymentIDs(ids...)
 }
 
+// AddDeploymentStatusIDs adds the "deployment_statuses" edge to the DeploymentStatus entity by IDs.
+func (ruo *RepoUpdateOne) AddDeploymentStatusIDs(ids ...int) *RepoUpdateOne {
+	ruo.mutation.AddDeploymentStatusIDs(ids...)
+	return ruo
+}
+
+// AddDeploymentStatuses adds the "deployment_statuses" edges to the DeploymentStatus entity.
+func (ruo *RepoUpdateOne) AddDeploymentStatuses(d ...*DeploymentStatus) *RepoUpdateOne {
+	ids := make([]int, len(d))
+	for i := range d {
+		ids[i] = d[i].ID
+	}
+	return ruo.AddDeploymentStatusIDs(ids...)
+}
+
 // AddLockIDs adds the "locks" edge to the Lock entity by IDs.
 func (ruo *RepoUpdateOne) AddLockIDs(ids ...int) *RepoUpdateOne {
 	ruo.mutation.AddLockIDs(ids...)
@@ -1002,6 +1108,27 @@ func (ruo *RepoUpdateOne) RemoveDeployments(d ...*Deployment) *RepoUpdateOne {
 		ids[i] = d[i].ID
 	}
 	return ruo.RemoveDeploymentIDs(ids...)
+}
+
+// ClearDeploymentStatuses clears all "deployment_statuses" edges to the DeploymentStatus entity.
+func (ruo *RepoUpdateOne) ClearDeploymentStatuses() *RepoUpdateOne {
+	ruo.mutation.ClearDeploymentStatuses()
+	return ruo
+}
+
+// RemoveDeploymentStatusIDs removes the "deployment_statuses" edge to DeploymentStatus entities by IDs.
+func (ruo *RepoUpdateOne) RemoveDeploymentStatusIDs(ids ...int) *RepoUpdateOne {
+	ruo.mutation.RemoveDeploymentStatusIDs(ids...)
+	return ruo
+}
+
+// RemoveDeploymentStatuses removes "deployment_statuses" edges to DeploymentStatus entities.
+func (ruo *RepoUpdateOne) RemoveDeploymentStatuses(d ...*DeploymentStatus) *RepoUpdateOne {
+	ids := make([]int, len(d))
+	for i := range d {
+		ids[i] = d[i].ID
+	}
+	return ruo.RemoveDeploymentStatusIDs(ids...)
 }
 
 // ClearLocks clears all "locks" edges to the Lock entity.
@@ -1339,6 +1466,60 @@ func (ruo *RepoUpdateOne) sqlSave(ctx context.Context) (_node *Repo, err error) 
 				IDSpec: &sqlgraph.FieldSpec{
 					Type:   field.TypeInt,
 					Column: deployment.FieldID,
+				},
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if ruo.mutation.DeploymentStatusesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   repo.DeploymentStatusesTable,
+			Columns: []string{repo.DeploymentStatusesColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt,
+					Column: deploymentstatus.FieldID,
+				},
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ruo.mutation.RemovedDeploymentStatusesIDs(); len(nodes) > 0 && !ruo.mutation.DeploymentStatusesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   repo.DeploymentStatusesTable,
+			Columns: []string{repo.DeploymentStatusesColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt,
+					Column: deploymentstatus.FieldID,
+				},
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ruo.mutation.DeploymentStatusesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   repo.DeploymentStatusesTable,
+			Columns: []string{repo.DeploymentStatusesColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt,
+					Column: deploymentstatus.FieldID,
 				},
 			},
 		}

--- a/model/ent/schema/deployment.go
+++ b/model/ent/schema/deployment.go
@@ -92,10 +92,6 @@ func (Deployment) Edges() []ent.Edge {
 			Annotations(entsql.Annotation{
 				OnDelete: entsql.Cascade,
 			}),
-		edge.To("event", Event.Type).
-			Annotations(entsql.Annotation{
-				OnDelete: entsql.Cascade,
-			}),
 	}
 }
 

--- a/model/ent/schema/deploymentstatus.go
+++ b/model/ent/schema/deploymentstatus.go
@@ -28,6 +28,9 @@ func (DeploymentStatus) Fields() []ent.Field {
 
 		// edges
 		field.Int("deployment_id"),
+		// Denormalize the 'repo_id' field so that
+		// we can figure out the repository easily.
+		field.Int64("repo_id"),
 	}
 }
 
@@ -37,6 +40,11 @@ func (DeploymentStatus) Edges() []ent.Edge {
 		edge.From("deployment", Deployment.Type).
 			Ref("deployment_statuses").
 			Field("deployment_id").
+			Unique().
+			Required(),
+		edge.From("repo", Repo.Type).
+			Ref("deployment_statuses").
+			Field("repo_id").
 			Unique().
 			Required(),
 		edge.To("event", Event.Type).

--- a/model/ent/schema/deploymentstatus.go
+++ b/model/ent/schema/deploymentstatus.go
@@ -30,7 +30,8 @@ func (DeploymentStatus) Fields() []ent.Field {
 		field.Int("deployment_id"),
 		// Denormalize the 'repo_id' field so that
 		// we can figure out the repository easily.
-		field.Int64("repo_id"),
+		field.Int64("repo_id").
+			Optional(),
 	}
 }
 
@@ -45,8 +46,7 @@ func (DeploymentStatus) Edges() []ent.Edge {
 		edge.From("repo", Repo.Type).
 			Ref("deployment_statuses").
 			Field("repo_id").
-			Unique().
-			Required(),
+			Unique(),
 		edge.To("event", Event.Type).
 			Annotations(entsql.Annotation{
 				OnDelete: entsql.Cascade,

--- a/model/ent/schema/deploymentstatus.go
+++ b/model/ent/schema/deploymentstatus.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"entgo.io/ent"
+	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 )
@@ -38,5 +39,9 @@ func (DeploymentStatus) Edges() []ent.Edge {
 			Field("deployment_id").
 			Unique().
 			Required(),
+		edge.To("event", Event.Type).
+			Annotations(entsql.Annotation{
+				OnDelete: entsql.Cascade,
+			}),
 	}
 }

--- a/model/ent/schema/event.go
+++ b/model/ent/schema/event.go
@@ -18,9 +18,8 @@ func (Event) Fields() []ent.Field {
 		field.Enum("kind").
 			Values(
 				"deployment",
+				"deployment_status",
 				"review",
-				// Deprecated values:
-				"approval",
 			),
 		field.Enum("type").
 			Values(
@@ -31,6 +30,8 @@ func (Event) Fields() []ent.Field {
 		field.Time("created_at").
 			Default(nowUTC),
 		field.Int("deployment_id").
+			Optional(),
+		field.Int("deployment_status_id").
 			Optional(),
 		field.Int("review_id").
 			Optional(),
@@ -46,6 +47,10 @@ func (Event) Edges() []ent.Edge {
 		edge.From("deployment", Deployment.Type).
 			Ref("event").
 			Field("deployment_id").
+			Unique(),
+		edge.From("deployment_status", DeploymentStatus.Type).
+			Ref("event").
+			Field("deployment_status_id").
 			Unique(),
 		edge.From("review", Review.Type).
 			Ref("event").

--- a/model/ent/schema/event.go
+++ b/model/ent/schema/event.go
@@ -17,7 +17,6 @@ func (Event) Fields() []ent.Field {
 	return []ent.Field{
 		field.Enum("kind").
 			Values(
-				"deployment",
 				"deployment_status",
 				"review",
 			),
@@ -29,8 +28,6 @@ func (Event) Fields() []ent.Field {
 			),
 		field.Time("created_at").
 			Default(nowUTC),
-		field.Int("deployment_id").
-			Optional(),
 		field.Int("deployment_status_id").
 			Optional(),
 		field.Int("review_id").
@@ -44,10 +41,6 @@ func (Event) Fields() []ent.Field {
 // Edges of the Event.
 func (Event) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.From("deployment", Deployment.Type).
-			Ref("event").
-			Field("deployment_id").
-			Unique(),
 		edge.From("deployment_status", DeploymentStatus.Type).
 			Ref("event").
 			Field("deployment_status_id").

--- a/model/ent/schema/repo.go
+++ b/model/ent/schema/repo.go
@@ -53,6 +53,10 @@ func (Repo) Edges() []ent.Edge {
 			Annotations(entsql.Annotation{
 				OnDelete: entsql.Cascade,
 			}),
+		edge.To("deployment_statuses", DeploymentStatus.Type).
+			Annotations(entsql.Annotation{
+				OnDelete: entsql.Cascade,
+			}),
 		edge.To("locks", Lock.Type).
 			Annotations(entsql.Annotation{
 				OnDelete: entsql.Cascade,

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -1438,10 +1438,12 @@ paths:
                       type: string
                       enum:
                         - deployment
+                        - deployment_status
                         - review
                     data:
                       oneOf:
                         - $ref: '#/components/schemas/Deployment'
+                        - $ref: '#/components/schemas/DeploymentStatus'
                         - $ref: '#/components/schemas/Review'
   /sync:
     post:

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -1751,11 +1751,24 @@ components:
           type: string
         updated_at:
           type: string
+        deployment_id:
+          type: number
+        repo_id:
+          type: number
+        edges:
+          type: object
+          properties:
+            deployment:
+              $ref: '#/components/schemas/DeploymentStatus'
+            repo:
+              $ref: '#/components/schemas/Repository'
       required:
         - id
         - status
         - created_at
         - updated_at
+        - deployment_id
+        - repo_id
     RemoteDeploymentStatus:
       type: object
       properties:

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -1437,12 +1437,10 @@ paths:
                     event:
                       type: string
                       enum:
-                        - deployment
                         - deployment_status
                         - review
                     data:
                       oneOf:
-                        - $ref: '#/components/schemas/Deployment'
                         - $ref: '#/components/schemas/DeploymentStatus'
                         - $ref: '#/components/schemas/Review'
   /sync:

--- a/ui/src/apis/deployment.ts
+++ b/ui/src/apis/deployment.ts
@@ -117,7 +117,8 @@ function mapDeploymentStatusEnum(s: string) {
     }
 }
 
-function mapDataToDeploymentStatus(data: any): DeploymentStatus {
+// eslint-disable-next-line
+export function mapDataToDeploymentStatus(data: any): DeploymentStatus {
     return {
         id: data.id,
         status: data.status,
@@ -125,6 +126,12 @@ function mapDataToDeploymentStatus(data: any): DeploymentStatus {
         logUrl: data.log_url,
         createdAt: data.created_at,
         updatedAt: data.updated_at,
+        deploymentId: data.deployment_id,
+        repoId: data.repo_id,
+        edges: {
+            deployment: (data.edges.deployment)? mapDataToDeployment(data.edges.deployment) : undefined,
+            repo: (data.edges.repo)? mapDataToRepo(data.edges.repo) : undefined
+        }
     }
 }
 

--- a/ui/src/apis/events.ts
+++ b/ui/src/apis/events.ts
@@ -1,8 +1,8 @@
 import { instance } from './setting'
 
-import { mapDataToDeployment } from "./deployment"
-import {  mapDataToReview } from "./review"
-import { Deployment, Review  } from "../models"
+import { mapDataToDeployment, mapDataToDeploymentStatus } from "./deployment"
+import { mapDataToReview } from "./review"
+import { Deployment, DeploymentStatus, Review  } from "../models"
 
 
 export const subscribeDeploymentEvents = (cb: (deployment: Deployment) => void): EventSource => {
@@ -15,6 +15,21 @@ export const subscribeDeploymentEvents = (cb: (deployment: Deployment) => void):
         const deployment = mapDataToDeployment(data)
 
         cb(deployment)
+    })
+
+    return sse
+}
+
+export const subscribeDeploymentStatusEvents = (cb: (status: DeploymentStatus) => void): EventSource => {
+    const sse = new EventSource(`${instance}/api/v1/stream/events`, {
+        withCredentials: true,
+    })
+
+    sse.addEventListener("deployment_status", (e: any) => {
+        const data = JSON.parse(e.data)
+        const status = mapDataToDeploymentStatus(data)
+
+        cb(status)
     })
 
     return sse

--- a/ui/src/apis/events.ts
+++ b/ui/src/apis/events.ts
@@ -1,24 +1,9 @@
 import { instance } from './setting'
 
-import { mapDataToDeployment, mapDataToDeploymentStatus } from "./deployment"
+import { mapDataToDeploymentStatus } from "./deployment"
 import { mapDataToReview } from "./review"
-import { Deployment, DeploymentStatus, Review  } from "../models"
+import { DeploymentStatus, Review  } from "../models"
 
-
-export const subscribeDeploymentEvents = (cb: (deployment: Deployment) => void): EventSource => {
-    const sse = new EventSource(`${instance}/api/v1/stream/events`, {
-        withCredentials: true,
-    })
-
-    sse.addEventListener("deployment", (e: any) => {
-        const data = JSON.parse(e.data)
-        const deployment = mapDataToDeployment(data)
-
-        cb(deployment)
-    })
-
-    return sse
-}
 
 export const subscribeDeploymentStatusEvents = (cb: (status: DeploymentStatus) => void): EventSource => {
     const sse = new EventSource(`${instance}/api/v1/stream/events`, {

--- a/ui/src/apis/index.ts
+++ b/ui/src/apis/index.ts
@@ -66,5 +66,6 @@ export {
 } from "./license"
 export { 
     subscribeDeploymentEvents,
+    subscribeDeploymentStatusEvents,
     subscribeReviewEvents,
 } from "./events"

--- a/ui/src/apis/index.ts
+++ b/ui/src/apis/index.ts
@@ -65,7 +65,6 @@ export {
     getLicense  
 } from "./license"
 export { 
-    subscribeDeploymentEvents,
     subscribeDeploymentStatusEvents,
     subscribeReviewEvents,
 } from "./events"

--- a/ui/src/models/Deployment.ts
+++ b/ui/src/models/Deployment.ts
@@ -41,4 +41,10 @@ export interface DeploymentStatus {
     logUrl: string
     createdAt: string
     updatedAt: string
+    deploymentId: number
+    repoId: number
+    edges?: {
+        deployment?: Deployment
+        repo?: Repo
+    }
 }

--- a/ui/src/redux/deployment.tsx
+++ b/ui/src/redux/deployment.tsx
@@ -194,11 +194,6 @@ export const deploymentSlice = createSlice({
         setDisplay: (state, action: PayloadAction<boolean>) => {
             state.display = action.payload
         },
-        handleDeploymentEvent: (state, action: PayloadAction<Deployment>) => {
-            if (action.payload.id === state.deployment?.id) {
-                state.deployment = action.payload
-            }
-        },
         handleReviewEvent: (state, action: PayloadAction<Review>) => {
             state.reviews = state.reviews.map((review) => {
                 return (action.payload.id === review.id)? action.payload : review

--- a/ui/src/redux/deployment.tsx
+++ b/ui/src/redux/deployment.tsx
@@ -3,6 +3,7 @@ import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit'
 
 import { 
     Deployment, 
+    DeploymentStatus,
     Commit,
     Review,
     RequestStatus, 
@@ -165,6 +166,21 @@ export const fetchUserReview = createAsyncThunk<Review, void, { state: {deployme
     },
 )
 
+export const handleDeploymentStatusEvent = createAsyncThunk<Deployment, DeploymentStatus, { state: { deployment: DeploymentState } }>(
+    "deployment/handleDeploymentStatusEvent",
+    async (deploymentStatus, { rejectWithValue }) => {
+        if (deploymentStatus.edges === undefined) {
+            return rejectWithValue(new Error("Edges is not included."))
+        }
+
+        const { repo, deployment } = deploymentStatus.edges
+        if (repo === undefined || deployment === undefined) {
+            return rejectWithValue(new Error("Repo or Deployment is not included in the edges."))
+        }
+
+        return await getDeployment(repo.namespace, repo.name, deployment.number)
+    }
+)
 
 export const deploymentSlice = createSlice({
     name: "deployment",
@@ -227,6 +243,11 @@ export const deploymentSlice = createSlice({
             })
             .addCase(fetchUserReview.fulfilled, (state, action) => {
                 state.userReview = action.payload
+            })
+            .addCase(handleDeploymentStatusEvent.fulfilled, (state, action) => {
+                if (action.payload.id === state.deployment?.id) {
+                    state.deployment = action.payload
+                }
             })
     }
 })

--- a/ui/src/views/deployment/index.tsx
+++ b/ui/src/views/deployment/index.tsx
@@ -14,6 +14,7 @@ import {
     fetchUserReview,
     approve,
     reject,
+    handleDeploymentStatusEvent
 } from "../../redux/deployment"
 import { 
     Deployment, 
@@ -24,6 +25,7 @@ import {
 } from "../../models"
 import { 
     subscribeDeploymentEvents, 
+    subscribeDeploymentStatusEvents,
     subscribeReviewEvents
 } from "../../apis"
 
@@ -68,12 +70,17 @@ export default (): JSX.Element => {
             dispatch(slice.actions.handleDeploymentEvent(deployment))
         })
 
+        const deploymentStatusEvent = subscribeDeploymentStatusEvents((deploymentStatus) => {
+            dispatch(handleDeploymentStatusEvent(deploymentStatus))
+        })
+
         const reviewEvent = subscribeReviewEvents((review) => {
             dispatch(slice.actions.handleReviewEvent(review))
         })
 
         return () => {
             deploymentEvent.close()
+            deploymentStatusEvent.close()
             reviewEvent.close()
         }
         // eslint-disable-next-line 

--- a/ui/src/views/deployment/index.tsx
+++ b/ui/src/views/deployment/index.tsx
@@ -24,7 +24,6 @@ import {
     RequestStatus
 } from "../../models"
 import { 
-    subscribeDeploymentEvents, 
     subscribeDeploymentStatusEvents,
     subscribeReviewEvents
 } from "../../apis"
@@ -66,10 +65,6 @@ export default (): JSX.Element => {
         }
         f()
 
-        const deploymentEvent = subscribeDeploymentEvents((deployment) => {
-            dispatch(slice.actions.handleDeploymentEvent(deployment))
-        })
-
         const deploymentStatusEvent = subscribeDeploymentStatusEvents((deploymentStatus) => {
             dispatch(handleDeploymentStatusEvent(deploymentStatus))
         })
@@ -79,7 +74,6 @@ export default (): JSX.Element => {
         })
 
         return () => {
-            deploymentEvent.close()
             deploymentStatusEvent.close()
             reviewEvent.close()
         }

--- a/ui/src/views/main/index.tsx
+++ b/ui/src/views/main/index.tsx
@@ -6,7 +6,6 @@ import moment from "moment"
 
 import { useAppSelector, useAppDispatch } from "../../redux/hooks"
 import { 
-    subscribeDeploymentEvents, 
     subscribeDeploymentStatusEvents,
     subscribeReviewEvents 
 } from "../../apis"
@@ -15,7 +14,6 @@ import {
     searchDeployments, 
     searchReviews, 
     fetchLicense, 
-    notifyDeploymentEvent, 
     notifyDeploymentStatusEvent,
     notifyReviewmentEvent, 
     handleDeploymentStatusEvent,
@@ -46,11 +44,6 @@ export default (props: React.PropsWithChildren<any>): JSX.Element => {
         dispatch(searchReviews())
         dispatch(fetchLicense())
 
-        const deploymentEvents = subscribeDeploymentEvents((deployment) => {
-            dispatch(slice.actions.handleDeploymentEvent(deployment))
-            dispatch(notifyDeploymentEvent(deployment))
-        })
-
         const deploymentStatusEvents = subscribeDeploymentStatusEvents((deploymentStatus) => {
             dispatch(handleDeploymentStatusEvent(deploymentStatus))
             dispatch(notifyDeploymentStatusEvent(deploymentStatus))
@@ -62,7 +55,6 @@ export default (props: React.PropsWithChildren<any>): JSX.Element => {
         })
 
         return () => {
-            deploymentEvents.close()
             deploymentStatusEvents.close()
             reviewEvents.close()
         }

--- a/ui/src/views/main/index.tsx
+++ b/ui/src/views/main/index.tsx
@@ -5,14 +5,20 @@ import { Helmet } from "react-helmet"
 import moment from "moment"
 
 import { useAppSelector, useAppDispatch } from "../../redux/hooks"
-import { subscribeDeploymentEvents, subscribeReviewEvents } from "../../apis"
+import { 
+    subscribeDeploymentEvents, 
+    subscribeDeploymentStatusEvents,
+    subscribeReviewEvents 
+} from "../../apis"
 import { 
     init, 
     searchDeployments, 
     searchReviews, 
     fetchLicense, 
     notifyDeploymentEvent, 
+    notifyDeploymentStatusEvent,
     notifyReviewmentEvent, 
+    handleDeploymentStatusEvent,
     mainSlice as slice 
 } from "../../redux/main"
 
@@ -45,6 +51,11 @@ export default (props: React.PropsWithChildren<any>): JSX.Element => {
             dispatch(notifyDeploymentEvent(deployment))
         })
 
+        const deploymentStatusEvents = subscribeDeploymentStatusEvents((deploymentStatus) => {
+            dispatch(handleDeploymentStatusEvent(deploymentStatus))
+            dispatch(notifyDeploymentStatusEvent(deploymentStatus))
+        })
+
         const reviewEvents = subscribeReviewEvents((review) => {
             dispatch(slice.actions.handleReviewEvent(review))
             dispatch(notifyReviewmentEvent(review))
@@ -52,6 +63,7 @@ export default (props: React.PropsWithChildren<any>): JSX.Element => {
 
         return () => {
             deploymentEvents.close()
+            deploymentStatusEvents.close()
             reviewEvents.close()
         }
     }, [dispatch])


### PR DESCRIPTION
## Description
When an event includes only a deployment, it isn't easy to get the status, description, and log_url of deployment status. To resolve this, we should add deployment_status as an event type and build a detailed notification message with a deployment status.

![image](https://user-images.githubusercontent.com/17633736/164892771-1e8c31a0-ebb5-4d99-a3ef-d3dd93907189.png)

## Schema 
The schema contains two changes: 1) By adding `deployment_status` as an event type, a notification can include status and description of deployment when fired. 2) Denormalize `repo_id` in `DeploymentStatus` to retrieve repository information.