### PR TITLE
Refactoring the event API

### DIFF
--- a/internal/server/api/v1/stream/events.go
+++ b/internal/server/api/v1/stream/events.go
@@ -7,7 +7,6 @@
 package stream
 
 import (
-	"math/rand"
 	"time"
 
 	"github.com/gin-contrib/sse"
@@ -110,14 +109,4 @@ L:
 			w.Flush()
 		}
 	}
-}
-
-func randstr() string {
-	var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-
-	b := make([]rune, 4)
-	for i := range b {
-		b[i] = letterRunes[rand.Intn(len(letterRunes))]
-	}
-	return string(b)
 }

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -1436,41 +1436,13 @@ paths:
                       type: integer
                     event:
                       type: string
+                      enum:
+                        - deployment
+                        - review
                     data:
-                      type: object 
-                      format: json 
-                      required:
-                        - id
-                        - kind
-                        - type
-                        - created_at
-                        - edges
-                      properties: 
-                        id:
-                          type: integer
-                        kind:
-                          type: string
-                          enum:
-                            - deployment
-                            - review
-                        type:
-                          type: string
-                          enum:
-                            - created
-                            - updated
-                            - deleted
-                        created_at:
-                          type: string
-                        deleted_id:
-                          type: integer
-                          description: The ID of deleted resource.
-                        edges:
-                          type: object
-                          properties:
-                            deployment:
-                              $ref: '#/components/schemas/Deployment'
-                            review:
-                              $ref: '#/components/schemas/Review'
+                      oneOf:
+                        - $ref: '#/components/schemas/Deployment'
+                        - $ref: '#/components/schemas/Review'
   /sync:
     post:
       tags:

--- a/ui/src/apis/events.ts
+++ b/ui/src/apis/events.ts
@@ -1,79 +1,35 @@
 import { instance } from './setting'
 
-import { DeploymentData, mapDataToDeployment } from "./deployment"
-import { ReviewData, mapDataToReview } from "./review"
-import { Deployment, Review, Event, EventKindEnum, EventTypeEnum } from "../models"
+import { mapDataToDeployment } from "./deployment"
+import {  mapDataToReview } from "./review"
+import { Deployment, Review  } from "../models"
 
-interface EventData {
-    id: number
-    kind: string
-    type: string
-    deleted_id: number
-    edges: {
-        deployment?: DeploymentData
-        review?: ReviewData
-    }
-}
 
-const mapDataToEvent = (data: EventData): Event => {
-    let kind: EventKindEnum
-    let type: EventTypeEnum
-    let deployment: Deployment | undefined
-    let review: Review | undefined
-
-    switch (data.kind) {
-        case "deployment":
-            kind = EventKindEnum.Deployment
-            break
-        case "review":
-            kind = EventKindEnum.Review
-            break
-        default:
-            kind = EventKindEnum.Deployment
-    }
-
-    switch (data.type) {
-        case "created":
-            type = EventTypeEnum.Created
-            break
-        case "updated":
-            type = EventTypeEnum.Updated
-            break
-        case "deleted":
-            type = EventTypeEnum.Deleted
-            break
-        default:
-            type = EventTypeEnum.Created
-    }
-
-    if (data.edges.deployment) {
-        deployment = mapDataToDeployment(data.edges.deployment)
-    }
-
-    if (data.edges.review) {
-        review = mapDataToReview(data.edges.review)
-    }
-
-    return {
-        id: data.id,
-        kind,
-        type,
-        deletedId: data.deleted_id,
-        deployment,
-        review
-    } 
-}
-
-export const subscribeEvents = (cb: (event: Event) => void): EventSource => {
+export const subscribeDeploymentEvents = (cb: (deployment: Deployment) => void): EventSource => {
     const sse = new EventSource(`${instance}/api/v1/stream/events`, {
         withCredentials: true,
     })
 
-    sse.addEventListener("event", (e: any) => {
+    sse.addEventListener("deployment", (e: any) => {
         const data = JSON.parse(e.data)
-        const event = mapDataToEvent(data)
+        const deployment = mapDataToDeployment(data)
 
-        cb(event)
+        cb(deployment)
+    })
+
+    return sse
+}
+
+export const subscribeReviewEvents = (cb: (review: Review) => void): EventSource => {
+    const sse = new EventSource(`${instance}/api/v1/stream/events`, {
+        withCredentials: true,
+    })
+
+    sse.addEventListener("review", (e: any) => {
+        const data = JSON.parse(e.data)
+        const review = mapDataToReview(data)
+
+        cb(review)
     })
 
     return sse

--- a/ui/src/apis/index.ts
+++ b/ui/src/apis/index.ts
@@ -1,5 +1,7 @@
-import { sync } from "./sync"
-import { 
+export {
+    sync 
+} from "./sync"
+export { 
     listRepos, 
     getRepo, 
     updateRepo, 
@@ -8,8 +10,10 @@ import {
     lockRepo,
     unlockRepo,
 } from "./repo"
-import { listPerms } from "./perm"
-import { 
+export { 
+    listPerms 
+} from "./perm"
+export { 
     searchDeployments, 
     listDeployments, 
     getDeployment,
@@ -18,68 +22,49 @@ import {
     rollbackDeployment, 
     listDeploymentChanges 
 } from './deployment'
-import { getConfig } from './config'
-import { listCommits, getCommit, listStatuses } from './commit'
-import { listBranches, getBranch } from './branch'
-import { listTags, getTag } from './tag'
-import { listUsers, updateUser, deleteUser, getMe, getRateLimit } from "./user"
-import { checkSlack } from "./chat"
-import {
+export {
+    getConfig 
+} from './config'
+export { 
+    listCommits, 
+    getCommit, 
+    listStatuses 
+} from './commit'
+export { 
+    listBranches, 
+    getBranch 
+} from './branch'
+export { 
+    listTags, 
+    getTag 
+} from './tag'
+export { 
+    listUsers, 
+    updateUser, 
+    deleteUser, 
+    getMe, 
+    getRateLimit 
+} from "./user"
+export { 
+    checkSlack 
+} from "./chat"
+export {
     searchReviews,
     listReviews,
     getUserReview,
     approveReview,
     rejectReview,
 } from "./review"
-import {
+export {
     listLocks,
     lock,
     unlock,
     updateLock
 } from "./lock"
-import { getLicense  } from "./license"
-import { subscribeEvents } from "./events"
-
-export {
-    sync,
-    listRepos,
-    getRepo,
-    updateRepo,
-    activateRepo,
-    deactivateRepo,
-    lockRepo,
-    unlockRepo,
-    listPerms,
-    searchDeployments,
-    listDeployments,
-    getDeployment,
-    createDeployment,
-    createRemoteDeployment,
-    rollbackDeployment,
-    listDeploymentChanges,
-    getConfig,
-    listCommits,
-    getCommit,
-    listStatuses,
-    listBranches,
-    getBranch,
-    listTags,
-    getTag,
-    listUsers,
-    updateUser,
-    deleteUser,
-    getMe,
-    getRateLimit,
-    checkSlack,
-    searchReviews,
-    listReviews,
-    getUserReview,
-    approveReview,
-    rejectReview,
-    listLocks,
-    lock,
-    unlock,
-    updateLock,
-    getLicense,
-    subscribeEvents
-}
+export { 
+    getLicense  
+} from "./license"
+export { 
+    subscribeDeploymentEvents,
+    subscribeReviewEvents,
+} from "./events"

--- a/ui/src/redux/deployment.tsx
+++ b/ui/src/redux/deployment.tsx
@@ -5,7 +5,6 @@ import {
     Deployment, 
     Commit,
     Review,
-    Event,
     RequestStatus, 
     HttpNotFoundError, 
     HttpForbiddenError,
@@ -179,18 +178,14 @@ export const deploymentSlice = createSlice({
         setDisplay: (state, action: PayloadAction<boolean>) => {
             state.display = action.payload
         },
-        handleDeploymentEvent: (state, action: PayloadAction<Event>) => {
-            const event = action.payload
-
-            if (event.deployment?.id !== state.deployment?.id) {
-                return
+        handleDeploymentEvent: (state, action: PayloadAction<Deployment>) => {
+            if (action.payload.id === state.deployment?.id) {
+                state.deployment = action.payload
             }
-
-            state.deployment = event.deployment
         },
-        handleReviewEvent: (state, action: PayloadAction<Event>) => {
+        handleReviewEvent: (state, action: PayloadAction<Review>) => {
             state.reviews = state.reviews.map((review) => {
-                return (review.id === action.payload.review?.id)? action.payload.review : review
+                return (action.payload.id === review.id)? action.payload : review
             })
         }
     },

--- a/ui/src/redux/home.ts
+++ b/ui/src/redux/home.ts
@@ -73,29 +73,6 @@ export const homeSlice = createSlice({
         decreasePage: (state) => {
             state.page = state.page - 1
         },
-        handleDeploymentEvent: (state, action: PayloadAction<Event>) => {
-            const event = action.payload
-            
-            state.repos = state.repos.map((repo) => {
-                if (event.deployment?.repo?.id !== repo.id) {
-                    return repo
-                }
-
-                if (!repo.deployments) {
-                    repo.deployments = []
-                }
-
-                if (event.type === EventTypeEnum.Created) {
-                    repo.deployments.unshift(event.deployment)
-                    return repo
-                }
-
-                repo.deployments = repo.deployments.map((deployment) => {
-                    return (event.deployment?.id === deployment.id )? event.deployment : deployment
-                })
-                return repo
-            })
-        },
     },
     extraReducers: builder => {
         builder

--- a/ui/src/redux/home.ts
+++ b/ui/src/redux/home.ts
@@ -3,8 +3,6 @@ import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit'
 import { 
     Repo, 
     RequestStatus, 
-    Event,
-    EventTypeEnum
 } from '../models'
 import * as apis from '../apis'
 

--- a/ui/src/redux/main.ts
+++ b/ui/src/redux/main.ts
@@ -139,9 +139,7 @@ const notify = (title: string, options?: NotificationOptions) => {
  */
 export const notifyDeploymentEvent = createAsyncThunk<void, Deployment, { state: { main: MainState } }>(
     "main/notifyDeploymentEvent",
-    async (deployment, { getState }) => {
-        const { user } = getState().main
-
+    async (deployment) => {
         if (deployment.status === DeploymentStatusEnum.Created) {
             notify(`New Deployment #${deployment.number}`, {
                 icon: "/logo192.png",
@@ -165,8 +163,7 @@ export const notifyDeploymentEvent = createAsyncThunk<void, Deployment, { state:
  */
 export const notifyReviewmentEvent = createAsyncThunk<void, Review, { state: { main: MainState } }>(
     "main/notifyReviewmentEvent",
-    async (review, { getState }) => {
-        const { user } = getState().main
+    async (review) => {
         if (review.status === ReviewStatusEnum.Pending) {
             notify(`Review Requested`, {
                 icon: "/logo192.png",

--- a/ui/src/redux/repoHome.ts
+++ b/ui/src/redux/repoHome.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction, createAsyncThunk } from '@reduxjs/toolkit'
 
-import { Deployment, Event, EventTypeEnum } from '../models'
+import { Deployment } from '../models'
 import { listDeployments, getConfig } from '../apis'
 
 export const perPage = 20;

--- a/ui/src/redux/repoHome.ts
+++ b/ui/src/redux/repoHome.ts
@@ -62,27 +62,6 @@ export const repoHomeSlice = createSlice({
         decreasePage: (state) => {
             state.page = state.page - 1
         },
-        handleDeploymentEvent: (state, action: PayloadAction<Event>) => {
-            const event = action.payload
-
-            if (!(event.deployment?.repo?.namespace === state.namespace 
-                && event.deployment?.repo?.name === state.name)) {
-                return
-            }
-
-            if (!(state.env === "" || event.deployment?.env === state.env)) {
-                return
-            }
-
-            if (event.type === EventTypeEnum.Created && event.deployment) {
-                state.deployments.unshift(event.deployment)
-                return
-            }
-
-            state.deployments = state.deployments.map((deployment) => {
-                return (event.deployment?.id ===  deployment.id)? event.deployment : deployment
-            })
-        },
     },
     extraReducers: builder => {
         builder

--- a/ui/src/views/deployment/index.tsx
+++ b/ui/src/views/deployment/index.tsx
@@ -22,7 +22,10 @@ import {
     ReviewStatusEnum,
     RequestStatus
 } from "../../models"
-import { subscribeEvents } from "../../apis"
+import { 
+    subscribeDeploymentEvents, 
+    subscribeReviewEvents
+} from "../../apis"
 
 import Main from "../main"
 import HeaderBreadcrumb, { HeaderBreadcrumbProps } from "./HeaderBreadcrumb"
@@ -61,13 +64,17 @@ export default (): JSX.Element => {
         }
         f()
 
-        const sub = subscribeEvents((event) => {
-            dispatch(slice.actions.handleDeploymentEvent(event))
-            dispatch(slice.actions.handleReviewEvent(event))
+        const deploymentEvent = subscribeDeploymentEvents((deployment) => {
+            dispatch(slice.actions.handleDeploymentEvent(deployment))
+        })
+
+        const reviewEvent = subscribeReviewEvents((review) => {
+            dispatch(slice.actions.handleReviewEvent(review))
         })
 
         return () => {
-            sub.close()
+            deploymentEvent.close()
+            reviewEvent.close()
         }
         // eslint-disable-next-line 
     }, [dispatch])

--- a/ui/src/views/home/index.tsx
+++ b/ui/src/views/home/index.tsx
@@ -7,7 +7,6 @@ import { RedoOutlined } from "@ant-design/icons"
 import { useAppSelector, useAppDispatch } from '../../redux/hooks'
 import { homeSlice, listRepos, perPage, sync, homeSlice as slice } from '../../redux/home'
 import { RequestStatus } from '../../models'
-import { subscribeEvents } from "../../apis"
 
 import Main from '../main'
 import RepoList, { RepoListProps } from './RepoList'
@@ -24,14 +23,6 @@ export default ():JSX.Element => {
 
     useEffect(() => {
         dispatch(listRepos())
-
-        const sub = subscribeEvents((event) => {
-            dispatch(slice.actions.handleDeploymentEvent(event))
-        })
-
-        return () => {
-            sub.close()
-        }
     }, [dispatch])
 
     const search = (q: string) => {

--- a/ui/src/views/home/index.tsx
+++ b/ui/src/views/home/index.tsx
@@ -5,7 +5,7 @@ import { Input, Breadcrumb, Button } from 'antd'
 import { RedoOutlined } from "@ant-design/icons"
 
 import { useAppSelector, useAppDispatch } from '../../redux/hooks'
-import { homeSlice, listRepos, perPage, sync, homeSlice as slice } from '../../redux/home'
+import { homeSlice, listRepos, perPage, sync } from '../../redux/home'
 import { RequestStatus } from '../../models'
 
 import Main from '../main'

--- a/ui/src/views/main/index.tsx
+++ b/ui/src/views/main/index.tsx
@@ -5,7 +5,7 @@ import { Helmet } from "react-helmet"
 import moment from "moment"
 
 import { useAppSelector, useAppDispatch } from "../../redux/hooks"
-import { subscribeEvents } from "../../apis"
+import { subscribeDeploymentEvents, subscribeReviewEvents } from "../../apis"
 import { 
     init, 
     searchDeployments, 
@@ -40,15 +40,19 @@ export default (props: React.PropsWithChildren<any>): JSX.Element => {
         dispatch(searchReviews())
         dispatch(fetchLicense())
 
-        const sub = subscribeEvents((event) => {
-            dispatch(slice.actions.handleDeploymentEvent(event))
-            dispatch(slice.actions.handleReviewEvent(event))
-            dispatch(notifyDeploymentEvent(event))
-            dispatch(notifyReviewmentEvent(event))
+        const deploymentEvents = subscribeDeploymentEvents((deployment) => {
+            dispatch(slice.actions.handleDeploymentEvent(deployment))
+            dispatch(notifyDeploymentEvent(deployment))
+        })
+
+        const reviewEvents = subscribeReviewEvents((review) => {
+            dispatch(slice.actions.handleReviewEvent(review))
+            dispatch(notifyReviewmentEvent(review))
         })
 
         return () => {
-            sub.close()
+            deploymentEvents.close()
+            reviewEvents.close()
         }
     }, [dispatch])
 

--- a/ui/src/views/repoHome/index.tsx
+++ b/ui/src/views/repoHome/index.tsx
@@ -5,7 +5,6 @@ import { PageHeader, Select } from 'antd'
 
 import { useAppSelector, useAppDispatch } from '../../redux/hooks'
 import { repoHomeSlice as slice, fetchEnvs, fetchDeployments, perPage } from '../../redux/repoHome'
-import { subscribeEvents } from "../../apis"
 
 import ActivityLogs, { ActivityLogsProps } from './ActivityLogs'
 import Spin from '../../components/Spin'
@@ -36,14 +35,6 @@ export default (): JSX.Element => {
         }
         f()
 
-        const sub = subscribeEvents((event) => {
-            dispatch(slice.actions.handleDeploymentEvent(event))
-        })
-
-        return () => {
-            sub.close()
-        }
-        // eslint-disable-next-line
     }, [dispatch])
 
     const onChangeEnv = (env: string) => {


### PR DESCRIPTION
I've replaced it with `Deployment` or `Review` entities for the stream event data(i.e., `event.data`). This change makes the UI code a bit simpler.