### PR TITLE
Fix the schema migration bug

### DIFF
--- a/model/ent/deployment.go
+++ b/model/ent/deployment.go
@@ -46,7 +46,7 @@ type Deployment struct {
 	// UpdatedAt holds the value of the "updated_at" field.
 	UpdatedAt time.Time `json:"updated_at"`
 	// UserID holds the value of the "user_id" field.
-	UserID int64 `json:"user_id"`
+	UserID int64 `json:"user_id,omitemtpy"`
 	// RepoID holds the value of the "repo_id" field.
 	RepoID int64 `json:"repo_id"`
 	// IsApprovalEnabled holds the value of the "is_approval_enabled" field.

--- a/model/ent/deployment/where.go
+++ b/model/ent/deployment/where.go
@@ -1167,6 +1167,20 @@ func UserIDNotIn(vs ...int64) predicate.Deployment {
 	})
 }
 
+// UserIDIsNil applies the IsNil predicate on the "user_id" field.
+func UserIDIsNil() predicate.Deployment {
+	return predicate.Deployment(func(s *sql.Selector) {
+		s.Where(sql.IsNull(s.C(FieldUserID)))
+	})
+}
+
+// UserIDNotNil applies the NotNil predicate on the "user_id" field.
+func UserIDNotNil() predicate.Deployment {
+	return predicate.Deployment(func(s *sql.Selector) {
+		s.Where(sql.NotNull(s.C(FieldUserID)))
+	})
+}
+
 // RepoIDEQ applies the EQ predicate on the "repo_id" field.
 func RepoIDEQ(v int64) predicate.Deployment {
 	return predicate.Deployment(func(s *sql.Selector) {

--- a/model/ent/deployment_create.go
+++ b/model/ent/deployment_create.go
@@ -180,6 +180,14 @@ func (dc *DeploymentCreate) SetUserID(i int64) *DeploymentCreate {
 	return dc
 }
 
+// SetNillableUserID sets the "user_id" field if the given value is not nil.
+func (dc *DeploymentCreate) SetNillableUserID(i *int64) *DeploymentCreate {
+	if i != nil {
+		dc.SetUserID(*i)
+	}
+	return dc
+}
+
 // SetRepoID sets the "repo_id" field.
 func (dc *DeploymentCreate) SetRepoID(i int64) *DeploymentCreate {
 	dc.mutation.SetRepoID(i)
@@ -395,14 +403,8 @@ func (dc *DeploymentCreate) check() error {
 	if _, ok := dc.mutation.UpdatedAt(); !ok {
 		return &ValidationError{Name: "updated_at", err: errors.New(`ent: missing required field "Deployment.updated_at"`)}
 	}
-	if _, ok := dc.mutation.UserID(); !ok {
-		return &ValidationError{Name: "user_id", err: errors.New(`ent: missing required field "Deployment.user_id"`)}
-	}
 	if _, ok := dc.mutation.RepoID(); !ok {
 		return &ValidationError{Name: "repo_id", err: errors.New(`ent: missing required field "Deployment.repo_id"`)}
-	}
-	if _, ok := dc.mutation.UserID(); !ok {
-		return &ValidationError{Name: "user", err: errors.New(`ent: missing required edge "Deployment.user"`)}
 	}
 	if _, ok := dc.mutation.RepoID(); !ok {
 		return &ValidationError{Name: "repo", err: errors.New(`ent: missing required edge "Deployment.repo"`)}

--- a/model/ent/deployment_update.go
+++ b/model/ent/deployment_update.go
@@ -218,6 +218,20 @@ func (du *DeploymentUpdate) SetUserID(i int64) *DeploymentUpdate {
 	return du
 }
 
+// SetNillableUserID sets the "user_id" field if the given value is not nil.
+func (du *DeploymentUpdate) SetNillableUserID(i *int64) *DeploymentUpdate {
+	if i != nil {
+		du.SetUserID(*i)
+	}
+	return du
+}
+
+// ClearUserID clears the value of the "user_id" field.
+func (du *DeploymentUpdate) ClearUserID() *DeploymentUpdate {
+	du.mutation.ClearUserID()
+	return du
+}
+
 // SetRepoID sets the "repo_id" field.
 func (du *DeploymentUpdate) SetRepoID(i int64) *DeploymentUpdate {
 	du.mutation.SetRepoID(i)
@@ -455,9 +469,6 @@ func (du *DeploymentUpdate) check() error {
 		if err := deployment.HTMLURLValidator(v); err != nil {
 			return &ValidationError{Name: "html_url", err: fmt.Errorf(`ent: validator failed for field "Deployment.html_url": %w`, err)}
 		}
-	}
-	if _, ok := du.mutation.UserID(); du.mutation.UserCleared() && !ok {
-		return errors.New(`ent: clearing a required unique edge "Deployment.user"`)
 	}
 	if _, ok := du.mutation.RepoID(); du.mutation.RepoCleared() && !ok {
 		return errors.New(`ent: clearing a required unique edge "Deployment.repo"`)
@@ -1028,6 +1039,20 @@ func (duo *DeploymentUpdateOne) SetUserID(i int64) *DeploymentUpdateOne {
 	return duo
 }
 
+// SetNillableUserID sets the "user_id" field if the given value is not nil.
+func (duo *DeploymentUpdateOne) SetNillableUserID(i *int64) *DeploymentUpdateOne {
+	if i != nil {
+		duo.SetUserID(*i)
+	}
+	return duo
+}
+
+// ClearUserID clears the value of the "user_id" field.
+func (duo *DeploymentUpdateOne) ClearUserID() *DeploymentUpdateOne {
+	duo.mutation.ClearUserID()
+	return duo
+}
+
 // SetRepoID sets the "repo_id" field.
 func (duo *DeploymentUpdateOne) SetRepoID(i int64) *DeploymentUpdateOne {
 	duo.mutation.SetRepoID(i)
@@ -1272,9 +1297,6 @@ func (duo *DeploymentUpdateOne) check() error {
 		if err := deployment.HTMLURLValidator(v); err != nil {
 			return &ValidationError{Name: "html_url", err: fmt.Errorf(`ent: validator failed for field "Deployment.html_url": %w`, err)}
 		}
-	}
-	if _, ok := duo.mutation.UserID(); duo.mutation.UserCleared() && !ok {
-		return errors.New(`ent: clearing a required unique edge "Deployment.user"`)
 	}
 	if _, ok := duo.mutation.RepoID(); duo.mutation.RepoCleared() && !ok {
 		return errors.New(`ent: clearing a required unique edge "Deployment.repo"`)

--- a/model/ent/lock.go
+++ b/model/ent/lock.go
@@ -25,7 +25,7 @@ type Lock struct {
 	// CreatedAt holds the value of the "created_at" field.
 	CreatedAt time.Time `json:"created_at"`
 	// UserID holds the value of the "user_id" field.
-	UserID int64 `json:"user_id"`
+	UserID int64 `json:"user_id,omitemtpy"`
 	// RepoID holds the value of the "repo_id" field.
 	RepoID int64 `json:"repo_id"`
 	// Edges holds the relations/edges for other nodes in the graph.

--- a/model/ent/lock/where.go
+++ b/model/ent/lock/where.go
@@ -453,6 +453,20 @@ func UserIDNotIn(vs ...int64) predicate.Lock {
 	})
 }
 
+// UserIDIsNil applies the IsNil predicate on the "user_id" field.
+func UserIDIsNil() predicate.Lock {
+	return predicate.Lock(func(s *sql.Selector) {
+		s.Where(sql.IsNull(s.C(FieldUserID)))
+	})
+}
+
+// UserIDNotNil applies the NotNil predicate on the "user_id" field.
+func UserIDNotNil() predicate.Lock {
+	return predicate.Lock(func(s *sql.Selector) {
+		s.Where(sql.NotNull(s.C(FieldUserID)))
+	})
+}
+
 // RepoIDEQ applies the EQ predicate on the "repo_id" field.
 func RepoIDEQ(v int64) predicate.Lock {
 	return predicate.Lock(func(s *sql.Selector) {

--- a/model/ent/lock_create.go
+++ b/model/ent/lock_create.go
@@ -62,6 +62,14 @@ func (lc *LockCreate) SetUserID(i int64) *LockCreate {
 	return lc
 }
 
+// SetNillableUserID sets the "user_id" field if the given value is not nil.
+func (lc *LockCreate) SetNillableUserID(i *int64) *LockCreate {
+	if i != nil {
+		lc.SetUserID(*i)
+	}
+	return lc
+}
+
 // SetRepoID sets the "repo_id" field.
 func (lc *LockCreate) SetRepoID(i int64) *LockCreate {
 	lc.mutation.SetRepoID(i)
@@ -163,14 +171,8 @@ func (lc *LockCreate) check() error {
 	if _, ok := lc.mutation.CreatedAt(); !ok {
 		return &ValidationError{Name: "created_at", err: errors.New(`ent: missing required field "Lock.created_at"`)}
 	}
-	if _, ok := lc.mutation.UserID(); !ok {
-		return &ValidationError{Name: "user_id", err: errors.New(`ent: missing required field "Lock.user_id"`)}
-	}
 	if _, ok := lc.mutation.RepoID(); !ok {
 		return &ValidationError{Name: "repo_id", err: errors.New(`ent: missing required field "Lock.repo_id"`)}
-	}
-	if _, ok := lc.mutation.UserID(); !ok {
-		return &ValidationError{Name: "user", err: errors.New(`ent: missing required edge "Lock.user"`)}
 	}
 	if _, ok := lc.mutation.RepoID(); !ok {
 		return &ValidationError{Name: "repo", err: errors.New(`ent: missing required edge "Lock.repo"`)}

--- a/model/ent/lock_update.go
+++ b/model/ent/lock_update.go
@@ -76,6 +76,20 @@ func (lu *LockUpdate) SetUserID(i int64) *LockUpdate {
 	return lu
 }
 
+// SetNillableUserID sets the "user_id" field if the given value is not nil.
+func (lu *LockUpdate) SetNillableUserID(i *int64) *LockUpdate {
+	if i != nil {
+		lu.SetUserID(*i)
+	}
+	return lu
+}
+
+// ClearUserID clears the value of the "user_id" field.
+func (lu *LockUpdate) ClearUserID() *LockUpdate {
+	lu.mutation.ClearUserID()
+	return lu
+}
+
 // SetRepoID sets the "repo_id" field.
 func (lu *LockUpdate) SetRepoID(i int64) *LockUpdate {
 	lu.mutation.SetRepoID(i)
@@ -171,9 +185,6 @@ func (lu *LockUpdate) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (lu *LockUpdate) check() error {
-	if _, ok := lu.mutation.UserID(); lu.mutation.UserCleared() && !ok {
-		return errors.New(`ent: clearing a required unique edge "Lock.user"`)
-	}
 	if _, ok := lu.mutation.RepoID(); lu.mutation.RepoCleared() && !ok {
 		return errors.New(`ent: clearing a required unique edge "Lock.repo"`)
 	}
@@ -360,6 +371,20 @@ func (luo *LockUpdateOne) SetUserID(i int64) *LockUpdateOne {
 	return luo
 }
 
+// SetNillableUserID sets the "user_id" field if the given value is not nil.
+func (luo *LockUpdateOne) SetNillableUserID(i *int64) *LockUpdateOne {
+	if i != nil {
+		luo.SetUserID(*i)
+	}
+	return luo
+}
+
+// ClearUserID clears the value of the "user_id" field.
+func (luo *LockUpdateOne) ClearUserID() *LockUpdateOne {
+	luo.mutation.ClearUserID()
+	return luo
+}
+
 // SetRepoID sets the "repo_id" field.
 func (luo *LockUpdateOne) SetRepoID(i int64) *LockUpdateOne {
 	luo.mutation.SetRepoID(i)
@@ -462,9 +487,6 @@ func (luo *LockUpdateOne) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (luo *LockUpdateOne) check() error {
-	if _, ok := luo.mutation.UserID(); luo.mutation.UserCleared() && !ok {
-		return errors.New(`ent: clearing a required unique edge "Lock.user"`)
-	}
 	if _, ok := luo.mutation.RepoID(); luo.mutation.RepoCleared() && !ok {
 		return errors.New(`ent: clearing a required unique edge "Lock.repo"`)
 	}

--- a/model/ent/migrate/schema.go
+++ b/model/ent/migrate/schema.go
@@ -254,7 +254,7 @@ var (
 	// NotificationRecordsColumns holds the columns for the "notification_records" table.
 	NotificationRecordsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
-		{Name: "event_id", Type: field.TypeInt, Unique: true},
+		{Name: "event_id", Type: field.TypeInt, Unique: true, Nullable: true},
 	}
 	// NotificationRecordsTable holds the schema information for the "notification_records" table.
 	NotificationRecordsTable = &schema.Table{
@@ -266,7 +266,7 @@ var (
 				Symbol:     "notification_records_events_notification_record",
 				Columns:    []*schema.Column{NotificationRecordsColumns[1]},
 				RefColumns: []*schema.Column{EventsColumns[0]},
-				OnDelete:   schema.Cascade,
+				OnDelete:   schema.SetNull,
 			},
 		},
 	}

--- a/model/ent/migrate/schema.go
+++ b/model/ent/migrate/schema.go
@@ -222,7 +222,7 @@ var (
 		{Name: "expired_at", Type: field.TypeTime, Nullable: true},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "repo_id", Type: field.TypeInt64},
-		{Name: "user_id", Type: field.TypeInt64},
+		{Name: "user_id", Type: field.TypeInt64, Nullable: true},
 	}
 	// LocksTable holds the schema information for the "locks" table.
 	LocksTable = &schema.Table{
@@ -240,7 +240,7 @@ var (
 				Symbol:     "locks_users_locks",
 				Columns:    []*schema.Column{LocksColumns[5]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
-				OnDelete:   schema.Cascade,
+				OnDelete:   schema.SetNull,
 			},
 		},
 		Indexes: []*schema.Index{

--- a/model/ent/migrate/schema.go
+++ b/model/ent/migrate/schema.go
@@ -52,7 +52,7 @@ var (
 		{Name: "is_approval_enabled", Type: field.TypeBool, Nullable: true},
 		{Name: "required_approval_count", Type: field.TypeInt, Nullable: true},
 		{Name: "repo_id", Type: field.TypeInt64},
-		{Name: "user_id", Type: field.TypeInt64},
+		{Name: "user_id", Type: field.TypeInt64, Nullable: true},
 	}
 	// DeploymentsTable holds the schema information for the "deployments" table.
 	DeploymentsTable = &schema.Table{
@@ -70,7 +70,7 @@ var (
 				Symbol:     "deployments_users_deployments",
 				Columns:    []*schema.Column{DeploymentsColumns[17]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
-				OnDelete:   schema.NoAction,
+				OnDelete:   schema.SetNull,
 			},
 		},
 		Indexes: []*schema.Index{
@@ -240,7 +240,7 @@ var (
 				Symbol:     "locks_users_locks",
 				Columns:    []*schema.Column{LocksColumns[5]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
-				OnDelete:   schema.NoAction,
+				OnDelete:   schema.Cascade,
 			},
 		},
 		Indexes: []*schema.Index{
@@ -266,7 +266,7 @@ var (
 				Symbol:     "notification_records_events_notification_record",
 				Columns:    []*schema.Column{NotificationRecordsColumns[1]},
 				RefColumns: []*schema.Column{EventsColumns[0]},
-				OnDelete:   schema.NoAction,
+				OnDelete:   schema.Cascade,
 			},
 		},
 	}
@@ -365,7 +365,7 @@ var (
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "deployment_id", Type: field.TypeInt},
-		{Name: "user_id", Type: field.TypeInt64},
+		{Name: "user_id", Type: field.TypeInt64, Nullable: true},
 	}
 	// ReviewsTable holds the schema information for the "reviews" table.
 	ReviewsTable = &schema.Table{
@@ -383,7 +383,7 @@ var (
 				Symbol:     "reviews_users_reviews",
 				Columns:    []*schema.Column{ReviewsColumns[6]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
-				OnDelete:   schema.NoAction,
+				OnDelete:   schema.SetNull,
 			},
 		},
 	}

--- a/model/ent/mutation.go
+++ b/model/ent/mutation.go
@@ -6099,9 +6099,22 @@ func (m *NotificationRecordMutation) OldEventID(ctx context.Context) (v int, err
 	return oldValue.EventID, nil
 }
 
+// ClearEventID clears the value of the "event_id" field.
+func (m *NotificationRecordMutation) ClearEventID() {
+	m.event = nil
+	m.clearedFields[notificationrecord.FieldEventID] = struct{}{}
+}
+
+// EventIDCleared returns if the "event_id" field was cleared in this mutation.
+func (m *NotificationRecordMutation) EventIDCleared() bool {
+	_, ok := m.clearedFields[notificationrecord.FieldEventID]
+	return ok
+}
+
 // ResetEventID resets all changes to the "event_id" field.
 func (m *NotificationRecordMutation) ResetEventID() {
 	m.event = nil
+	delete(m.clearedFields, notificationrecord.FieldEventID)
 }
 
 // ClearEvent clears the "event" edge to the Event entity.
@@ -6111,7 +6124,7 @@ func (m *NotificationRecordMutation) ClearEvent() {
 
 // EventCleared reports if the "event" edge to the Event entity was cleared.
 func (m *NotificationRecordMutation) EventCleared() bool {
-	return m.clearedevent
+	return m.EventIDCleared() || m.clearedevent
 }
 
 // EventIDs returns the "event" edge IDs in the mutation.
@@ -6222,7 +6235,11 @@ func (m *NotificationRecordMutation) AddField(name string, value ent.Value) erro
 // ClearedFields returns all nullable fields that were cleared during this
 // mutation.
 func (m *NotificationRecordMutation) ClearedFields() []string {
-	return nil
+	var fields []string
+	if m.FieldCleared(notificationrecord.FieldEventID) {
+		fields = append(fields, notificationrecord.FieldEventID)
+	}
+	return fields
 }
 
 // FieldCleared returns a boolean indicating if a field with the given name was
@@ -6235,6 +6252,11 @@ func (m *NotificationRecordMutation) FieldCleared(name string) bool {
 // ClearField clears the value of the field with the given name. It returns an
 // error if the field is not defined in the schema.
 func (m *NotificationRecordMutation) ClearField(name string) error {
+	switch name {
+	case notificationrecord.FieldEventID:
+		m.ClearEventID()
+		return nil
+	}
 	return fmt.Errorf("unknown NotificationRecord nullable field %s", name)
 }
 

--- a/model/ent/mutation.go
+++ b/model/ent/mutation.go
@@ -5554,9 +5554,22 @@ func (m *LockMutation) OldUserID(ctx context.Context) (v int64, err error) {
 	return oldValue.UserID, nil
 }
 
+// ClearUserID clears the value of the "user_id" field.
+func (m *LockMutation) ClearUserID() {
+	m.user = nil
+	m.clearedFields[lock.FieldUserID] = struct{}{}
+}
+
+// UserIDCleared returns if the "user_id" field was cleared in this mutation.
+func (m *LockMutation) UserIDCleared() bool {
+	_, ok := m.clearedFields[lock.FieldUserID]
+	return ok
+}
+
 // ResetUserID resets all changes to the "user_id" field.
 func (m *LockMutation) ResetUserID() {
 	m.user = nil
+	delete(m.clearedFields, lock.FieldUserID)
 }
 
 // SetRepoID sets the "repo_id" field.
@@ -5602,7 +5615,7 @@ func (m *LockMutation) ClearUser() {
 
 // UserCleared reports if the "user" edge to the User entity was cleared.
 func (m *LockMutation) UserCleared() bool {
-	return m.cleareduser
+	return m.UserIDCleared() || m.cleareduser
 }
 
 // UserIDs returns the "user" edge IDs in the mutation.
@@ -5799,6 +5812,9 @@ func (m *LockMutation) ClearedFields() []string {
 	if m.FieldCleared(lock.FieldExpiredAt) {
 		fields = append(fields, lock.FieldExpiredAt)
 	}
+	if m.FieldCleared(lock.FieldUserID) {
+		fields = append(fields, lock.FieldUserID)
+	}
 	return fields
 }
 
@@ -5815,6 +5831,9 @@ func (m *LockMutation) ClearField(name string) error {
 	switch name {
 	case lock.FieldExpiredAt:
 		m.ClearExpiredAt()
+		return nil
+	case lock.FieldUserID:
+		m.ClearUserID()
 		return nil
 	}
 	return fmt.Errorf("unknown Lock nullable field %s", name)

--- a/model/ent/mutation.go
+++ b/model/ent/mutation.go
@@ -1476,9 +1476,22 @@ func (m *DeploymentMutation) OldUserID(ctx context.Context) (v int64, err error)
 	return oldValue.UserID, nil
 }
 
+// ClearUserID clears the value of the "user_id" field.
+func (m *DeploymentMutation) ClearUserID() {
+	m.user = nil
+	m.clearedFields[deployment.FieldUserID] = struct{}{}
+}
+
+// UserIDCleared returns if the "user_id" field was cleared in this mutation.
+func (m *DeploymentMutation) UserIDCleared() bool {
+	_, ok := m.clearedFields[deployment.FieldUserID]
+	return ok
+}
+
 // ResetUserID resets all changes to the "user_id" field.
 func (m *DeploymentMutation) ResetUserID() {
 	m.user = nil
+	delete(m.clearedFields, deployment.FieldUserID)
 }
 
 // SetRepoID sets the "repo_id" field.
@@ -1643,7 +1656,7 @@ func (m *DeploymentMutation) ClearUser() {
 
 // UserCleared reports if the "user" edge to the User entity was cleared.
 func (m *DeploymentMutation) UserCleared() bool {
-	return m.cleareduser
+	return m.UserIDCleared() || m.cleareduser
 }
 
 // UserIDs returns the "user" edge IDs in the mutation.
@@ -2161,6 +2174,9 @@ func (m *DeploymentMutation) ClearedFields() []string {
 	if m.FieldCleared(deployment.FieldHTMLURL) {
 		fields = append(fields, deployment.FieldHTMLURL)
 	}
+	if m.FieldCleared(deployment.FieldUserID) {
+		fields = append(fields, deployment.FieldUserID)
+	}
 	if m.FieldCleared(deployment.FieldIsApprovalEnabled) {
 		fields = append(fields, deployment.FieldIsApprovalEnabled)
 	}
@@ -2192,6 +2208,9 @@ func (m *DeploymentMutation) ClearField(name string) error {
 		return nil
 	case deployment.FieldHTMLURL:
 		m.ClearHTMLURL()
+		return nil
+	case deployment.FieldUserID:
+		m.ClearUserID()
 		return nil
 	case deployment.FieldIsApprovalEnabled:
 		m.ClearIsApprovalEnabled()
@@ -8672,9 +8691,22 @@ func (m *ReviewMutation) OldUserID(ctx context.Context) (v int64, err error) {
 	return oldValue.UserID, nil
 }
 
+// ClearUserID clears the value of the "user_id" field.
+func (m *ReviewMutation) ClearUserID() {
+	m.user = nil
+	m.clearedFields[review.FieldUserID] = struct{}{}
+}
+
+// UserIDCleared returns if the "user_id" field was cleared in this mutation.
+func (m *ReviewMutation) UserIDCleared() bool {
+	_, ok := m.clearedFields[review.FieldUserID]
+	return ok
+}
+
 // ResetUserID resets all changes to the "user_id" field.
 func (m *ReviewMutation) ResetUserID() {
 	m.user = nil
+	delete(m.clearedFields, review.FieldUserID)
 }
 
 // SetDeploymentID sets the "deployment_id" field.
@@ -8720,7 +8752,7 @@ func (m *ReviewMutation) ClearUser() {
 
 // UserCleared reports if the "user" edge to the User entity was cleared.
 func (m *ReviewMutation) UserCleared() bool {
-	return m.cleareduser
+	return m.UserIDCleared() || m.cleareduser
 }
 
 // UserIDs returns the "user" edge IDs in the mutation.
@@ -8985,6 +9017,9 @@ func (m *ReviewMutation) ClearedFields() []string {
 	if m.FieldCleared(review.FieldComment) {
 		fields = append(fields, review.FieldComment)
 	}
+	if m.FieldCleared(review.FieldUserID) {
+		fields = append(fields, review.FieldUserID)
+	}
 	return fields
 }
 
@@ -9001,6 +9036,9 @@ func (m *ReviewMutation) ClearField(name string) error {
 	switch name {
 	case review.FieldComment:
 		m.ClearComment()
+		return nil
+	case review.FieldUserID:
+		m.ClearUserID()
 		return nil
 	}
 	return fmt.Errorf("unknown Review nullable field %s", name)

--- a/model/ent/notificationrecord.go
+++ b/model/ent/notificationrecord.go
@@ -17,7 +17,7 @@ type NotificationRecord struct {
 	// ID of the ent.
 	ID int `json:"id,omitempty"`
 	// EventID holds the value of the "event_id" field.
-	EventID int `json:"event_id"`
+	EventID int `json:"event_id,omitemtpy"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the NotificationRecordQuery when eager-loading is set.
 	Edges NotificationRecordEdges `json:"edges"`

--- a/model/ent/notificationrecord/where.go
+++ b/model/ent/notificationrecord/where.go
@@ -146,6 +146,20 @@ func EventIDNotIn(vs ...int) predicate.NotificationRecord {
 	})
 }
 
+// EventIDIsNil applies the IsNil predicate on the "event_id" field.
+func EventIDIsNil() predicate.NotificationRecord {
+	return predicate.NotificationRecord(func(s *sql.Selector) {
+		s.Where(sql.IsNull(s.C(FieldEventID)))
+	})
+}
+
+// EventIDNotNil applies the NotNil predicate on the "event_id" field.
+func EventIDNotNil() predicate.NotificationRecord {
+	return predicate.NotificationRecord(func(s *sql.Selector) {
+		s.Where(sql.NotNull(s.C(FieldEventID)))
+	})
+}
+
 // HasEvent applies the HasEdge predicate on the "event" edge.
 func HasEvent() predicate.NotificationRecord {
 	return predicate.NotificationRecord(func(s *sql.Selector) {

--- a/model/ent/notificationrecord_create.go
+++ b/model/ent/notificationrecord_create.go
@@ -4,7 +4,6 @@ package ent
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"entgo.io/ent/dialect/sql/sqlgraph"
@@ -23,6 +22,14 @@ type NotificationRecordCreate struct {
 // SetEventID sets the "event_id" field.
 func (nrc *NotificationRecordCreate) SetEventID(i int) *NotificationRecordCreate {
 	nrc.mutation.SetEventID(i)
+	return nrc
+}
+
+// SetNillableEventID sets the "event_id" field if the given value is not nil.
+func (nrc *NotificationRecordCreate) SetNillableEventID(i *int) *NotificationRecordCreate {
+	if i != nil {
+		nrc.SetEventID(*i)
+	}
 	return nrc
 }
 
@@ -101,12 +108,6 @@ func (nrc *NotificationRecordCreate) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (nrc *NotificationRecordCreate) check() error {
-	if _, ok := nrc.mutation.EventID(); !ok {
-		return &ValidationError{Name: "event_id", err: errors.New(`ent: missing required field "NotificationRecord.event_id"`)}
-	}
-	if _, ok := nrc.mutation.EventID(); !ok {
-		return &ValidationError{Name: "event", err: errors.New(`ent: missing required edge "NotificationRecord.event"`)}
-	}
 	return nil
 }
 

--- a/model/ent/notificationrecord_query.go
+++ b/model/ent/notificationrecord_query.go
@@ -293,7 +293,7 @@ func (nrq *NotificationRecordQuery) WithEvent(opts ...func(*EventQuery)) *Notifi
 // Example:
 //
 //	var v []struct {
-//		EventID int `json:"event_id"`
+//		EventID int `json:"event_id,omitemtpy"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
@@ -320,7 +320,7 @@ func (nrq *NotificationRecordQuery) GroupBy(field string, fields ...string) *Not
 // Example:
 //
 //	var v []struct {
-//		EventID int `json:"event_id"`
+//		EventID int `json:"event_id,omitemtpy"`
 //	}
 //
 //	client.NotificationRecord.Query().

--- a/model/ent/notificationrecord_update.go
+++ b/model/ent/notificationrecord_update.go
@@ -34,6 +34,20 @@ func (nru *NotificationRecordUpdate) SetEventID(i int) *NotificationRecordUpdate
 	return nru
 }
 
+// SetNillableEventID sets the "event_id" field if the given value is not nil.
+func (nru *NotificationRecordUpdate) SetNillableEventID(i *int) *NotificationRecordUpdate {
+	if i != nil {
+		nru.SetEventID(*i)
+	}
+	return nru
+}
+
+// ClearEventID clears the value of the "event_id" field.
+func (nru *NotificationRecordUpdate) ClearEventID() *NotificationRecordUpdate {
+	nru.mutation.ClearEventID()
+	return nru
+}
+
 // SetEvent sets the "event" edge to the Event entity.
 func (nru *NotificationRecordUpdate) SetEvent(e *Event) *NotificationRecordUpdate {
 	return nru.SetEventID(e.ID)
@@ -57,18 +71,12 @@ func (nru *NotificationRecordUpdate) Save(ctx context.Context) (int, error) {
 		affected int
 	)
 	if len(nru.hooks) == 0 {
-		if err = nru.check(); err != nil {
-			return 0, err
-		}
 		affected, err = nru.sqlSave(ctx)
 	} else {
 		var mut Mutator = MutateFunc(func(ctx context.Context, m Mutation) (Value, error) {
 			mutation, ok := m.(*NotificationRecordMutation)
 			if !ok {
 				return nil, fmt.Errorf("unexpected mutation type %T", m)
-			}
-			if err = nru.check(); err != nil {
-				return 0, err
 			}
 			nru.mutation = mutation
 			affected, err = nru.sqlSave(ctx)
@@ -108,14 +116,6 @@ func (nru *NotificationRecordUpdate) ExecX(ctx context.Context) {
 	if err := nru.Exec(ctx); err != nil {
 		panic(err)
 	}
-}
-
-// check runs all checks and user-defined validators on the builder.
-func (nru *NotificationRecordUpdate) check() error {
-	if _, ok := nru.mutation.EventID(); nru.mutation.EventCleared() && !ok {
-		return errors.New(`ent: clearing a required unique edge "NotificationRecord.event"`)
-	}
-	return nil
 }
 
 func (nru *NotificationRecordUpdate) sqlSave(ctx context.Context) (n int, err error) {
@@ -196,6 +196,20 @@ func (nruo *NotificationRecordUpdateOne) SetEventID(i int) *NotificationRecordUp
 	return nruo
 }
 
+// SetNillableEventID sets the "event_id" field if the given value is not nil.
+func (nruo *NotificationRecordUpdateOne) SetNillableEventID(i *int) *NotificationRecordUpdateOne {
+	if i != nil {
+		nruo.SetEventID(*i)
+	}
+	return nruo
+}
+
+// ClearEventID clears the value of the "event_id" field.
+func (nruo *NotificationRecordUpdateOne) ClearEventID() *NotificationRecordUpdateOne {
+	nruo.mutation.ClearEventID()
+	return nruo
+}
+
 // SetEvent sets the "event" edge to the Event entity.
 func (nruo *NotificationRecordUpdateOne) SetEvent(e *Event) *NotificationRecordUpdateOne {
 	return nruo.SetEventID(e.ID)
@@ -226,18 +240,12 @@ func (nruo *NotificationRecordUpdateOne) Save(ctx context.Context) (*Notificatio
 		node *NotificationRecord
 	)
 	if len(nruo.hooks) == 0 {
-		if err = nruo.check(); err != nil {
-			return nil, err
-		}
 		node, err = nruo.sqlSave(ctx)
 	} else {
 		var mut Mutator = MutateFunc(func(ctx context.Context, m Mutation) (Value, error) {
 			mutation, ok := m.(*NotificationRecordMutation)
 			if !ok {
 				return nil, fmt.Errorf("unexpected mutation type %T", m)
-			}
-			if err = nruo.check(); err != nil {
-				return nil, err
 			}
 			nruo.mutation = mutation
 			node, err = nruo.sqlSave(ctx)
@@ -277,14 +285,6 @@ func (nruo *NotificationRecordUpdateOne) ExecX(ctx context.Context) {
 	if err := nruo.Exec(ctx); err != nil {
 		panic(err)
 	}
-}
-
-// check runs all checks and user-defined validators on the builder.
-func (nruo *NotificationRecordUpdateOne) check() error {
-	if _, ok := nruo.mutation.EventID(); nruo.mutation.EventCleared() && !ok {
-		return errors.New(`ent: clearing a required unique edge "NotificationRecord.event"`)
-	}
-	return nil
 }
 
 func (nruo *NotificationRecordUpdateOne) sqlSave(ctx context.Context) (_node *NotificationRecord, err error) {

--- a/model/ent/review.go
+++ b/model/ent/review.go
@@ -27,7 +27,7 @@ type Review struct {
 	// UpdatedAt holds the value of the "updated_at" field.
 	UpdatedAt time.Time `json:"updated_at"`
 	// UserID holds the value of the "user_id" field.
-	UserID int64 `json:"user_id"`
+	UserID int64 `json:"user_id,omitemtpy"`
 	// DeploymentID holds the value of the "deployment_id" field.
 	DeploymentID int `json:"deployment_id"`
 	// Edges holds the relations/edges for other nodes in the graph.

--- a/model/ent/review/where.go
+++ b/model/ent/review/where.go
@@ -501,6 +501,20 @@ func UserIDNotIn(vs ...int64) predicate.Review {
 	})
 }
 
+// UserIDIsNil applies the IsNil predicate on the "user_id" field.
+func UserIDIsNil() predicate.Review {
+	return predicate.Review(func(s *sql.Selector) {
+		s.Where(sql.IsNull(s.C(FieldUserID)))
+	})
+}
+
+// UserIDNotNil applies the NotNil predicate on the "user_id" field.
+func UserIDNotNil() predicate.Review {
+	return predicate.Review(func(s *sql.Selector) {
+		s.Where(sql.NotNull(s.C(FieldUserID)))
+	})
+}
+
 // DeploymentIDEQ applies the EQ predicate on the "deployment_id" field.
 func DeploymentIDEQ(v int) predicate.Review {
 	return predicate.Review(func(s *sql.Selector) {

--- a/model/ent/review_create.go
+++ b/model/ent/review_create.go
@@ -85,6 +85,14 @@ func (rc *ReviewCreate) SetUserID(i int64) *ReviewCreate {
 	return rc
 }
 
+// SetNillableUserID sets the "user_id" field if the given value is not nil.
+func (rc *ReviewCreate) SetNillableUserID(i *int64) *ReviewCreate {
+	if i != nil {
+		rc.SetUserID(*i)
+	}
+	return rc
+}
+
 // SetDeploymentID sets the "deployment_id" field.
 func (rc *ReviewCreate) SetDeploymentID(i int) *ReviewCreate {
 	rc.mutation.SetDeploymentID(i)
@@ -217,14 +225,8 @@ func (rc *ReviewCreate) check() error {
 	if _, ok := rc.mutation.UpdatedAt(); !ok {
 		return &ValidationError{Name: "updated_at", err: errors.New(`ent: missing required field "Review.updated_at"`)}
 	}
-	if _, ok := rc.mutation.UserID(); !ok {
-		return &ValidationError{Name: "user_id", err: errors.New(`ent: missing required field "Review.user_id"`)}
-	}
 	if _, ok := rc.mutation.DeploymentID(); !ok {
 		return &ValidationError{Name: "deployment_id", err: errors.New(`ent: missing required field "Review.deployment_id"`)}
-	}
-	if _, ok := rc.mutation.UserID(); !ok {
-		return &ValidationError{Name: "user", err: errors.New(`ent: missing required edge "Review.user"`)}
 	}
 	if _, ok := rc.mutation.DeploymentID(); !ok {
 		return &ValidationError{Name: "deployment", err: errors.New(`ent: missing required edge "Review.deployment"`)}

--- a/model/ent/review_update.go
+++ b/model/ent/review_update.go
@@ -91,6 +91,20 @@ func (ru *ReviewUpdate) SetUserID(i int64) *ReviewUpdate {
 	return ru
 }
 
+// SetNillableUserID sets the "user_id" field if the given value is not nil.
+func (ru *ReviewUpdate) SetNillableUserID(i *int64) *ReviewUpdate {
+	if i != nil {
+		ru.SetUserID(*i)
+	}
+	return ru
+}
+
+// ClearUserID clears the value of the "user_id" field.
+func (ru *ReviewUpdate) ClearUserID() *ReviewUpdate {
+	ru.mutation.ClearUserID()
+	return ru
+}
+
 // SetDeploymentID sets the "deployment_id" field.
 func (ru *ReviewUpdate) SetDeploymentID(i int) *ReviewUpdate {
 	ru.mutation.SetDeploymentID(i)
@@ -235,9 +249,6 @@ func (ru *ReviewUpdate) check() error {
 		if err := review.StatusValidator(v); err != nil {
 			return &ValidationError{Name: "status", err: fmt.Errorf(`ent: validator failed for field "Review.status": %w`, err)}
 		}
-	}
-	if _, ok := ru.mutation.UserID(); ru.mutation.UserCleared() && !ok {
-		return errors.New(`ent: clearing a required unique edge "Review.user"`)
 	}
 	if _, ok := ru.mutation.DeploymentID(); ru.mutation.DeploymentCleared() && !ok {
 		return errors.New(`ent: clearing a required unique edge "Review.deployment"`)
@@ -500,6 +511,20 @@ func (ruo *ReviewUpdateOne) SetUserID(i int64) *ReviewUpdateOne {
 	return ruo
 }
 
+// SetNillableUserID sets the "user_id" field if the given value is not nil.
+func (ruo *ReviewUpdateOne) SetNillableUserID(i *int64) *ReviewUpdateOne {
+	if i != nil {
+		ruo.SetUserID(*i)
+	}
+	return ruo
+}
+
+// ClearUserID clears the value of the "user_id" field.
+func (ruo *ReviewUpdateOne) ClearUserID() *ReviewUpdateOne {
+	ruo.mutation.ClearUserID()
+	return ruo
+}
+
 // SetDeploymentID sets the "deployment_id" field.
 func (ruo *ReviewUpdateOne) SetDeploymentID(i int) *ReviewUpdateOne {
 	ruo.mutation.SetDeploymentID(i)
@@ -651,9 +676,6 @@ func (ruo *ReviewUpdateOne) check() error {
 		if err := review.StatusValidator(v); err != nil {
 			return &ValidationError{Name: "status", err: fmt.Errorf(`ent: validator failed for field "Review.status": %w`, err)}
 		}
-	}
-	if _, ok := ruo.mutation.UserID(); ruo.mutation.UserCleared() && !ok {
-		return errors.New(`ent: clearing a required unique edge "Review.user"`)
 	}
 	if _, ok := ruo.mutation.DeploymentID(); ruo.mutation.DeploymentCleared() && !ok {
 		return errors.New(`ent: clearing a required unique edge "Review.deployment"`)

--- a/model/ent/schema/deployment.go
+++ b/model/ent/schema/deployment.go
@@ -78,8 +78,7 @@ func (Deployment) Edges() []ent.Edge {
 		edge.From("user", User.Type).
 			Ref("deployments").
 			Field("user_id").
-			Unique().
-			Required(),
+			Unique(),
 		edge.From("repo", Repo.Type).
 			Ref("deployments").
 			Field("repo_id").

--- a/model/ent/schema/deployment.go
+++ b/model/ent/schema/deployment.go
@@ -58,7 +58,8 @@ func (Deployment) Fields() []ent.Field {
 			Default(nowUTC).
 			UpdateDefault(nowUTC),
 		// Edges
-		field.Int64("user_id"),
+		field.Int64("user_id").
+			Optional(),
 		field.Int64("repo_id"),
 
 		// Deprecated fields.

--- a/model/ent/schema/event.go
+++ b/model/ent/schema/event.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"entgo.io/ent"
+	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
@@ -50,6 +51,9 @@ func (Event) Edges() []ent.Edge {
 			Field("review_id").
 			Unique(),
 		edge.To("notification_record", NotificationRecord.Type).
+			Annotations(entsql.Annotation{
+				OnDelete: entsql.Cascade,
+			}).
 			Unique(),
 	}
 }

--- a/model/ent/schema/event.go
+++ b/model/ent/schema/event.go
@@ -52,7 +52,7 @@ func (Event) Edges() []ent.Edge {
 			Unique(),
 		edge.To("notification_record", NotificationRecord.Type).
 			Annotations(entsql.Annotation{
-				OnDelete: entsql.Cascade,
+				OnDelete: entsql.SetNull,
 			}).
 			Unique(),
 	}

--- a/model/ent/schema/lock.go
+++ b/model/ent/schema/lock.go
@@ -22,7 +22,8 @@ func (Lock) Fields() []ent.Field {
 		field.Time("created_at").
 			Default(nowUTC),
 		// Edges
-		field.Int64("user_id"),
+		field.Int64("user_id").
+			Optional(),
 		field.Int64("repo_id"),
 	}
 }
@@ -33,8 +34,7 @@ func (Lock) Edges() []ent.Edge {
 		edge.From("user", User.Type).
 			Ref("locks").
 			Field("user_id").
-			Unique().
-			Required(),
+			Unique(),
 		edge.From("repo", Repo.Type).
 			Ref("locks").
 			Field("repo_id").

--- a/model/ent/schema/notificationrecord.go
+++ b/model/ent/schema/notificationrecord.go
@@ -14,7 +14,8 @@ type NotificationRecord struct {
 // Fields of the NotificationRecord.
 func (NotificationRecord) Fields() []ent.Field {
 	return []ent.Field{
-		field.Int("event_id"),
+		field.Int("event_id").
+			Optional(),
 	}
 }
 
@@ -24,7 +25,6 @@ func (NotificationRecord) Edges() []ent.Edge {
 		edge.From("event", Event.Type).
 			Ref("notification_record").
 			Field("event_id").
-			Unique().
-			Required(),
+			Unique(),
 	}
 }

--- a/model/ent/schema/review.go
+++ b/model/ent/schema/review.go
@@ -30,7 +30,8 @@ func (Review) Fields() []ent.Field {
 			Default(nowUTC).
 			UpdateDefault(nowUTC),
 		// Edges
-		field.Int64("user_id"),
+		field.Int64("user_id").
+			Optional(),
 		field.Int("deployment_id"),
 	}
 }

--- a/model/ent/schema/review.go
+++ b/model/ent/schema/review.go
@@ -42,8 +42,7 @@ func (Review) Edges() []ent.Edge {
 		edge.From("user", User.Type).
 			Ref("reviews").
 			Field("user_id").
-			Unique().
-			Required(),
+			Unique(),
 		edge.From("deployment", Deployment.Type).
 			Ref("reviews").
 			Field("deployment_id").

--- a/model/ent/schema/user.go
+++ b/model/ent/schema/user.go
@@ -51,9 +51,21 @@ func (User) Edges() []ent.Edge {
 			Annotations(entsql.Annotation{
 				OnDelete: entsql.Cascade,
 			}),
-		edge.To("deployments", Deployment.Type),
-		edge.To("reviews", Review.Type),
-		edge.To("locks", Lock.Type),
-		edge.To("repos", Repo.Type),
+		edge.To("deployments", Deployment.Type).
+			Annotations(entsql.Annotation{
+				OnDelete: entsql.SetNull,
+			}),
+		edge.To("reviews", Review.Type).
+			Annotations(entsql.Annotation{
+				OnDelete: entsql.SetNull,
+			}),
+		edge.To("locks", Lock.Type).
+			Annotations(entsql.Annotation{
+				OnDelete: entsql.Cascade,
+			}),
+		edge.To("repos", Repo.Type).
+			Annotations(entsql.Annotation{
+				OnDelete: entsql.SetNull,
+			}),
 	}
 }

--- a/model/ent/schema/user.go
+++ b/model/ent/schema/user.go
@@ -51,6 +51,7 @@ func (User) Edges() []ent.Edge {
 			Annotations(entsql.Annotation{
 				OnDelete: entsql.Cascade,
 			}),
+		// In order to record the history, when a user is deleted, it is filled with a null value.
 		edge.To("deployments", Deployment.Type).
 			Annotations(entsql.Annotation{
 				OnDelete: entsql.SetNull,
@@ -61,7 +62,7 @@ func (User) Edges() []ent.Edge {
 			}),
 		edge.To("locks", Lock.Type).
 			Annotations(entsql.Annotation{
-				OnDelete: entsql.Cascade,
+				OnDelete: entsql.SetNull,
 			}),
 		edge.To("repos", Repo.Type).
 			Annotations(entsql.Annotation{


### PR DESCRIPTION
A schema migration error occurs for the MySQL database. The error is that while upgrading the Ent, the default value of the foreign key constraint has changed(#381). To avoid this, rever to the same value as before.