### PR TITLE
Fix the bug of notification ID

### DIFF
--- a/ui/src/redux/main.ts
+++ b/ui/src/redux/main.ts
@@ -170,7 +170,7 @@ export const notifyDeploymentStatusEvent = createAsyncThunk<
     notify(`${repo.namespace}/${repo.name} #${deployment.number}`, {
       icon: '/logo192.png',
       body: `${deploymentStatus.status} - ${deploymentStatus.description}`,
-      tag: String(deployment.id),
+      tag: String(deploymentStatus.id),
     });
   }
 );


### PR DESCRIPTION
It has the bug all notifications except the first notification under a deployment are missed on the browser because the same `tag` suppress to avoid the users' screen is filled up with a huge number of similar notifications. So we have to change into the deployment status ID so all notifications can be displayed in the browser.